### PR TITLE
Add courses for Swiss German keyboard layout (ch)

### DIFF
--- a/data/courses/CMakeLists.txt
+++ b/data/courses/CMakeLists.txt
@@ -4,6 +4,8 @@ set (coursefiles
     bg2.xml
     br.xml
     cat.xml
+    ch1.xml
+    ch2.xml
     cz.xml
     de.dvorak.xml
     de.neo.xml

--- a/data/courses/ch1.xml
+++ b/data/courses/ch1.xml
@@ -1,0 +1,958 @@
+<?xml version="1.0"?>
+<course>
+ <id>{7361fd17-5457-48e1-b118-a59a429c734b}</id>
+ <title>Deutsch (CH)</title>
+ <description>Deutscher Kurs für KTouch von Markus Frisch &lt;frisch@vr-web.de>  (Modified for Swiss keyboard layout)</description>
+ <keyboardLayout>ch</keyboardLayout>
+ <lessons>
+  <lesson>
+   <id>{2774dd77-8077-4c6e-ad25-915f0fc135b1}</id>
+   <title>Grundstellung (1)</title>
+   <newCharacters>asdfjklö</newCharacters>
+   <text>fff fff fff jjj jjj jjj fff fff jjj jjj fff jjj fff jjj fff
+fjf fjf fjf jfj jfj jfj fjf fjf fjf jfj jfj jfj fjf jfj fjf
+ddd ddd ddd kkk kkk kkk ddd ddd kkk kkk ddd kkk ddd kkk ddd
+dkd dkd dkd kdk kdk kdk dkd dkd dkd kdk kdk kdk dkd kdk dkd
+fjf dkd fjf dkd fjd dkd fjf dkd jfj kdk jfj kdk jfj kdk jfj
+aaa aaa aaa ööö ööö ööö aaa aaa ööö ööö aaa ööö aaa ööö aaa
+fff jjj ddd kkk aaa ööö fff jjj ddd kkk aaa ööö fff jjj ddd
+aöa aöa aöa öaö öaö öaö fjf dkd aöa fjf dkd aöa jfj kdk öaö
+sss sss sss lll lll lll sss sss lll lll sss lll sss lll sss
+sls sls sls lsl lsl lsl sls sls sls lsl lsl lsl sls sls sls
+fff jjj ddd kkk aaa ööö sss lll fff jjj ddd kkk aaa ööö sss</text>
+  </lesson>
+  <lesson>
+   <id>{54341371-a0d2-4fc8-8e3e-58e252734459}</id>
+   <title>Grundstellung (2)</title>
+   <newCharacters></newCharacters>
+   <text>asdf jklö asdf jklö asdf jklö asdf jklö asdf jklö asdf jklö
+asdf fdsa ölkj fdsa ölkj fdsa ölkj fdsa ölkj fdsa ölkj fds
+ölkj fdsa asdf jklö fdsa ölkj asdf jklö fdsa ölkj asdf jklö
+la la la ka ka ka sö sö sö dö dö dö la la la ka ka ka sö sö
+al al al ak ak ak ös ös ös öd öd öd al al al ak ak ak ös ös
+ja ja ja da da da ja ja ja da da da ja ja ja da da da ja ja
+öd öd öd ja ja ja öd öd öd da da da öd öd öd ja ja ja öd öd
+fad fad fad las las las fad fad fad las las las fad fad fad
+als als als fad fad fad las las las als als als fad fad fad
+lös lös lös als als als fad fad fad lös lös lös als als als
+das das das als als als das als das als als das als das als
+las las las das das das las das las das das las das las das
+da das lös das da das las ja las ja las ja öd ja lös da das
+ja lös ja lös als lös lös da fad da fad da öd öd fad ja lös
+das las dass das las dass das las dass das las dass dass ja</text>
+  </lesson>
+  <lesson>
+   <id>{11308ce5-334c-4dc9-addc-7ace2b0a805c}</id>
+   <title>e und i</title>
+   <newCharacters>ei</newCharacters>
+   <text>ded ded ded dej dek del deö ded deö del dek dej ded dej dek
+ded ded dea dea des des def def ded ded dea dea des des def
+ede ede ede edj edj edk edl edö edf eds ede ede edj edj edk
+öde öde öde ade ade ade öle öle öle ade ade öde öde ade ade
+alle alle alle lade lade lade alle alles lade lade alles las
+löse löse löse jede jede jede löse löse jede jede löse jede
+kik kik kik kif kid kis kia kik kia kis kid kif kik kis kia
+kik kik kiö kiö kil kil kik kik kij kij kik kil kiö kil kij
+iki iki ikf ikd iks ikj ikl ikö ikf ded kik ded kik ded kik
+sie sie sie sei sei sei sie sie sei sei sie sie sei sei seid
+die die die sie sie sie die die sie sie die die sie sie die
+seid seid seid dies dies dies seid seid dies dies seid dies
+fiel fiel fiel lief lief lief fiel fiel lief lief fiel leise
+feil feil feil fiel fiel fiel lief lief fiel fiel feil fidel
+seid seid seid fiel fiel feil feil seid seid lief lief fiel
+dies dies lief feil seid seid feil lief fiel dies seid leise
+ideal ideal ideal fidel fidel fidel ideal ideal fidel fidel
+leise leise leise ideal ideal ideal leise leise ideal leise
+alles alles alles leise leise leise alles alles leise alles
+feil feil feil seid seid seid dies dies dies fiel fiel fiel
+seid fiel dies feil dies fiel seid feil fiel seid dies seid
+diese diese diese leise leise leise diese diese leise leise
+leise leise diese diese lasse lasse leise lasse diese lasse
+diese leise lasse diese leise lasse lasse leise diese leise
+ideal ideal ideal fidel fidel fidel ideal ideal fidel fidel
+alles alles alles ideal ideal ideal alles alles ideal ideal
+las lasse das dass las lasse das dass las lasse das dass
+jede jede ödes ödes dass dass jede jede ödes ödes dass dass</text>
+  </lesson>
+  <lesson>
+   <id>{177d39e3-aa45-4de6-95a9-5c16141f3cb7}</id>
+   <title>r und u</title>
+   <newCharacters>ru</newCharacters>
+   <text>ded frf frf frf frj frk frl fri frf frd frs fra frf fri fra
+dir dir dir dar dar dar dir dir dar dar dir dar dir dar dir
+leer leer leer reif reif reif leer leer reif reif leer reif
+aller aller aller reise reise reise aller aller reise reise
+freie freie freie klare klare klare freie freie klare klare
+jeder jeder jeder raffe raffe raffe jeder jeder raffe raffe
+kik juj juj juj juf jud jus jua juj juk jul juö juj juk jul
+aus aus aus auf auf auf aus aus auf auf aus auf aus auf aus
+faul faul faul rufe rufe rufe faul faul rufe rufe faul rufe
+kaufe kaufe kaufe laufe laufe laufe kaufe kaufe laufe laufe
+dulde dulde dulde freue freue freue dulde dulde freue freue
+flaue flaue flaue dulde dulde klare klare flaue dulde klare</text>
+  </lesson>
+  <lesson>
+   <id>{fd8732c0-fbfc-49cc-a80d-5031713fb8ac}</id>
+   <title>, und .</title>
+   <newCharacters>,.</newCharacters>
+   <text>kik k,k kik k,k k,a k,s k,d k,f kik k,k k,a k,s k,d k,f kik
+k,k l.l l.l l.l l.a l.s l.d l.f l.l l.a l.s l.d l.f k,i l.l
+k,ö k,l k,j l.ö l.k l.j k,k l.l k,k l.l k,ö l.ö k,j l.j k,k
+ideal, ideal. fidel, fidel. ideal, ideal. fidel, fidel. es,
+dass. jedes, jedes. diese, diese. jedes, jedes. diese, dies.
+da, jede. alles, alles. leise, leise. alles, alles. leise,
+leise. ja, alle. es dauere, es dauere. leider flau, leider
+flau. alles frei, leer. alles klar, alles klar. alles reif,
+alles reif. das sei dir klar. leider leer, leider leer.
+leider sauer, leider sauer. erfasse es. dass er erfasse,
+dass er erfasse. ja, dass sie das alles erfasse. erlasse
+dies, erlasse dies. erlasse das alles. er erlasse es dir. er
+rufe, er rufe es. er rufe aus, er dulde es. leider alles
+leer. er lasse, er lasse es. er erlasse das, er fasse auf,
+erfasse das. sei fair, dass er fair sei, dass sie fair sei,
+dass sie fair sei. leere es aus, erfasse es, dass er es
+erfasse, dass er es erfasse.</text>
+  </lesson>
+  <lesson>
+   <id>{ca5f626f-c2b7-4afa-95f7-f373ccc69566}</id>
+   <title>Uebung</title>
+   <newCharacters></newCharacters>
+   <text>sause sause sause sauer sauer sauer raufe raufe raufe sause
+sauer sauer sauer raufe raufe sause sause sauer raufe sause
+sauer raufe dar darauf darauf darauf daraus daraus daraus
+darauf daraus drauf dir dauere dauere dauere leeres leeres
+leeres dauere leeres leere rar erlasse erlasse erlasse
+erfasse erfasse erfasse erlasse fasse liefere lief liefere
+darauf darauf darauf liefere leer leider lasse leider leer,
+flau, leider faul, leider leer, liefere alles, alles frei,
+alles klar, alles reif, alles leer, erfasse das, klar, er
+rufe, er rufe es, er rufe dir, er dulde es, sie dulde es,
+dass er lasse, er lasse es, er erlasse das, er fasse, er
+erfasse alles, alles klar, alles frei, alles reif, alles
+leer, erfasse das klar, er dulde, er dulde es, rede leise,
+sie rief aus, er liefere alles, er kaufe, kaufe alles, kaufe
+alles auf, sie kaufe alles auf, alle liefere dies, liefere
+alles, liefere es, liefere alles aus, rufe, rufe das aus,
+rufe dies aus, rufe dies alles aus, rufe aus, alles erlasse
+es, erlasse dies, erlasse dieses, leider dies alles leer.</text>
+  </lesson>
+  <lesson>
+   <id>{08a5a01c-1f7c-4218-b91c-15c7e1de71b3}</id>
+   <title>linker Umschalter und rechter Umschalter</title>
+   <newCharacters>ASDFJKLEIRU</newCharacters>
+   <text>jJa jJa Ja Ja Ja Jade Jade Jade kKa kKa Ka Ka Ka Kadi Kaffee
+lLa lLa La La La Lauf Lauf Lauf öa öa öa öa öa öse öse öse
+Jura Jura Jura Kauf Kauf Kauf Laie Laie Laie
+das Ufer, das Ufer, der Ural, der Ural, das Ufer, Julia
+die Idee, die Idee, die Isar, die Isar, die Idee, die Isar.
+der Jude, die Kufe, die Laus, der Usus, der Irak, das Leid.
+fFö fFö Fö Fö Fö Frau Frau Frau dDö dDö Dö Dö Dö Dill Diskus
+sSö sSö Sö Sö Sö Seil Seil Seil aAö aAö Aö Aö Aö Affe Afrika
+Fall Fall Fall Dirk Dirk Dirk Saal Saal Saal Adel Adel Adler
+die Rede, die Rede, die Rede, der Reis, der Reis, die Reue.
+die Eile, die Eile, die Eile, die Elle, die Elle, der Efeu.
+das Fass, der Dill, die Saar, der Akku, der Reis, die Eule.
+Jade Jade Fall Fall Kauf Kauf Dill Dill Lied Lied Jade Kajak
+Ulla Ulla Rudi Rudi Ilse Ilse Ella Ella Ulla Rudi Ilse Iller
+der Juli, der Juli, das Feld, das Feld, der Juli, die Jade.
+der Klee, der Klee, die Dias, die Dias, der Klee, der Kies.
+die Luke, die Luke, das Safe, das Safe, die Luke, das Safe.
+der Ulk, der Ulk, das Rad, das Rad, der Ire, der Erlass.
+der Jak, die Fee, die Kur, das Dur, das Lid, die Ideale.
+der Jura, der Fakir, die Kasse, die Diele, der Lakai, Ralf.
+der Keller, die Dekade, der Kessel, der Diskus, die Klasse.
+der Kurier, der Diesel, die Kreide, der Dussel, der Kaiser.</text>
+  </lesson>
+  <lesson>
+   <id>{89822ef8-d840-4e4b-8351-50291b82bb70}</id>
+   <title>Umschalter (2)</title>
+   <newCharacters></newCharacters>
+   <text>Er rufe Karl. Sie rufe Fred aus Kassel. Er rufe Ida aus
+Adelaide. Ella, rede leise. Erika, rede leise. Julia aus
+Riesa. Rede leiser. Karl, kaufe Reis. Ilse, kaufe Reis. Ida,
+kaufe Kaffee aus Afrika Ulf, liefere Eiskaffee. Alfred,
+liefere die Rasierseife aus Fulda. Er rufe Karl. Er rufe
+Karl aus Kassel. Sie rufe Karla aus Kassel. Edi, rede leise.
+Erika, rede leiser. Ilse, aus Riesa, rede leise. Else,
+liefere Eiskaffee. Else, liefere Eiskaffee. Else liefere es.
+Er rufe Fred aus Kassel. Er rufe Fred aus Kassel. Er rufe
+Frieda. Karl, kaufe Kaffee. Karl, kaufe Kaffee aus Jaffa.
+Karla kaufe es. Er rufe Fred. Ida rufe Fred aus Fulda. Erika
+rufe Fred aus Fulda. Alfred, liefere diese Rasierseife aus
+Kassel. Alfred liefere alles. Else kaufe diese Seife. Erika
+kaufe diese Seife. Klara kaufe sie. Dirk rede leiser. Ella,
+rede leiser. Dirk aus Adelaide. Rede leise.</text>
+  </lesson>
+  <lesson>
+   <id>{c7057355-a5e0-408d-a8e3-79bcb85a4249}</id>
+   <title>g und h</title>
+   <newCharacters>ghGH</newCharacters>
+   <text>fgf fgf fgf fgö fgl fgk fgj fgf fga fgs fgd fgf fga fgs fgd
+gfa gfs gfd gfg gri gri gru gru gre gre gri gru gre gri gru
+lag lag lag gar gar gar lag lag gar gar lag lag gar gar lag
+klage klug klug klug sage sage sage klug klug sage sage klug
+sage kluge grau grau grau karg karg karg grau grau karg karg
+griff griff griff grell grell grell griff griff grell grell
+Sieg Sieg Sieg Auge Auge Auge Sieg Sieg Auge Auge Sieg Sieg
+Geld Geld Geld Gier Gier Gier Geld Geld Gier Gier Geld Geld
+Girl Girl Girl Gras Gras Gras Girl Girl Gras Gras Girl Girl
+jhj jhj jhj jha jhs jhd jhf jhj jhö jhl jhk jhö jhl jhk jhö
+hjö hjl hjk hjö hjl hjk hjö jhj jhk jhl jhö hjö hjl hjk hjh
+aha aha aha sah sah sah her her her aha aha sah sah her her
+ehe ehe ehe ihr ihr ihr ehe ehe ihr ihr her her sah ehe ihr
+kahl kahl kahl fahl fahl fahl kahl kahl fahl fahl kahl kahl
+hell hell hell ihre ihre ihre sehr sehr sehr hell ihre sehr
+ruhig ruhig ruhig fahre fahre fahre ruhig ruhig fahre fahre
+leihe leihe leihe siehe siehe siehe leihe leihe siehe siehe
+herauf herauf heraus heraus herauf herauf heraus geduldige
+Ruhr Ruhr Ruhr Dreh Dreh Dreh Ruhr Ruhr Dreh Dreh Ruhr Reihe
+Hals Hals Hals Hass Hass Hass Hals Hals Hass Hass Hals Hafer
+Haus Haus Haus Held Held Held Haus Haus Held Held Haus Halle
+gehöre gehöre gehöre ruhige ruhige ruhige gehöre religiöse
+lehre lehre lehre heile heile heile lehre lehre heile heile
+helle helle helle graue graue graue helle helle graue graue
+sehr diesig, sehr eifrig, sehr gierig, sehr grell, sehr grau</text>
+  </lesson>
+  <lesson>
+   <id>{9ebd0559-9a93-4a9c-8d92-3caa479b2b02}</id>
+   <title>g und h (2)</title>
+   <newCharacters></newCharacters>
+   <text>gerade heraus, gerade erfuhr er es, gerade lieh er das alles
+aus, es sei eilig, es sei sehr eilig, es sei eiliger, er
+erfahre dies, siehe her, siehe herauf, siehe hierher, es
+lag, das lag hier aus, erledige das, erledige alles, höre
+eilig auf, erledige es freudig, hilf ihr, es sei sehr heil,
+dies sei ruhig, sie sei hier ruhiger, das sei sehr hell, das
+sei arg, sie erfuhr es, er erfuhr es hier, er fuhr ruhig, er
+fuhr ruhiger, lege es heraus, hier lag das aus, sie las
+eifrig, sie las das alles sehr eifrig, er las das eifrig,
+das sei grell, dies sei greller, da lag es, er griff es hier
+auf, der Guss, das Haar, der Graf, die Hefe, das Gras, die
+Hufe, Röhre aus Gera, aus Kehl, aus Eger, aus Lahr, aus
+Suhl, aus Gera, Kehle Rufe Gerd aus Kehl. Rufe Hedi aus
+Gera. Rufe Hildegard aus Halle. Frage Ida aus Kassel. Frage
+Ulla aus Lahr. Frage Harald aus Gera. Gerda fuhr das Rad.
+Hilde fuhr das Rad. Gerd fuhr dieses Fahrrad. Harald sah
+diese Auslage. Erhard sah diese Auslage. Er sah alles. Der
+Hausherr fuhr auf der Allee. Die Hausfrau fuhr auf der
+Allee. Hilde gefiel das helle Kleid. Der Ehefrau gefiel das
+graue Kleid. Edgar leihe dir das Glas. Gerda leihe dir die
+Geige. Er sah dies. Gerade fuhr Harald aus der Garage. Heike
+aus Rheda fuhr das Krad. Edgar fuhr sehr ruhig. Gerda las
+eifrig. Der Geselle erledige es. Höre auf die Hilferufe.
+Karl höre auf die Hilferufe. Es lag hier. Der Flieger sah
+die Segel. Der Geselle aus Krefeld sah das Radar.</text>
+  </lesson>
+  <lesson>
+   <id>{67a53685-4892-4edc-9bf5-a2d9f2e81cc4}</id>
+   <title>t und z</title>
+   <newCharacters>tzTZ</newCharacters>
+   <text>frf ftf ftf ftf frf fta fts ftd fta fts ftd tfö tfl tfk tfj
+hat hat hat tut tut tut hat hat tut tut hat tut tut hat tut
+gut gut gut tat tat tat gut gut tat tat gut tat tat gut tat
+kalt kalt kalt tief tief tief laut laut laut hart hart hart
+kalte riet riet riet erst erst erst riet riet erst erst riet
+erst erste alte alte alte fast fast fast alte alte fast fast
+alte fast altes hatte gutes tief alte fast riet erst tat gut
+Lift Lift Lift Last Last Last Lift Lift Lift Last Last Last
+Karte Takt Takt Takt Teig Teig Teig Takt Takt Teig Teig Takt
+Teig Tasse Taler Taler Taler These These These Taler Taler
+These These Taler Takt Zeit Karte Teig Last Zeitgeist Takt
+juj jzj jzj jzj juj jzj jzö jzl jzk jzö jzl jzk jzö zjl zjk
+kurz kurz kurz zart zart zart kurz kurz zart zart kurz zart
+kurze zielt zielt zielt sitzt sitzt sitzt zielt zielt sitzt
+sitzt zielt geizig geizig geizig zögert zögert zögert geizig
+zögert zersetzte zerfiel zerfiel zerfiel zergeht zergeht
+zerfiel zerstreut hitzige heftige heftige hitzig dreisitzig
+jetzt jetzt jetzt ritzt ritzt ritzt jetzt jetzt ritzt ritzt
+zerstreut zerstreut zerstreut zersetzte zersetzte zerstreut
+Arzt Arzt Arzt Herz Herz Herz Arzt Arzt Herz Herz Arzt Kreuz
+Salz Salz Salz Zeit Zeit Zeit Salz Salz Zeit Zeit Salz Zitat
+Zahl Zahl Zahl Ziel Ziel Ziel Zahl Zahl Ziel Ziel Zahl Zeuge
+ehrgeizig ehrgeizig ehrgeizig ersetztes ersetztes kulturell
+sitzt zuletzt zuletzt zuletzt zuerst zuerst zuerst zuletzt
+zuerst herzu reduziert reduziert reduziert kulturell ziert</text>
+  </lesson>
+  <lesson>
+   <id>{e0347667-20cf-4e38-b592-1cc1a383753e}</id>
+   <title>t und z (2)</title>
+   <newCharacters></newCharacters>
+   <text>Heftig gestört, heute erzielt, heftig gestört, er zahlt es
+jetzt, erst reduziert, es ist heiter, erst reduziert, sie
+zögerte jetzt, zuerst ersetzt, sie liest gut, zuerst
+ersetzt, er ist jetzt hier, zeige das, zeige es klar,
+du hast gehört, du hattest alles gehört, leite es, leite es
+gut, leite alle gut, er hat alles gut geleitet, er zahlte
+es, er zahlte alles aus, er zahlte alles erst jetzt aus, sie
+teilt es auf, er teilt es jetzt auf, er teilt jetzt alles
+auf. er hat alles ersetzt, sie hatte alles gut ersetzt, er
+hatte dies, du hast alles gehört, du hattest alles gut
+gehört, sie sagte aus, sie sagte es klar, sie sagte das
+alles sehr klar, er hört darauf, er hat gezahlt, er hat
+jetzt gezahlt, sie hat es jetzt ausgezahlt, der Teelöffel,
+der Zeh, das Tal, der Tag, das Zeug, die Tat, die Kritik.
+Der Teil, der Test, die Art, das Zelt, der Teig, der Gast.
+Die Tageskarte, die Last, die Katze, das Tier, das Fest,
+der Zug. Das Zitat hast du sehr gut aufgesagt. Daher ist
+Kritik gestattet. Du sagst, dass sie erregt ist. Du klagst,
+dass sie zerstreut ist. Der Gast leert das Sektglas. Dieser
+Gast diskutierte sehr heftig. Das Zelt aus Halle ist sehr
+gut. Das Resultat steht zurzeit fest. Die Zufahrt ist leider
+zu kurz. Die Katze sitzt auf der Terrasse. Edith kritisierte
+alle Tarife. Das Theater zeigt kulturelles Gut. Freitag
+kauft Ruth ihre Theaterkarte. Gertrud kauft Reitstiefel. Der
+Artikel ist jetzt stark reduziert. Der Zeuge sagte alles
+aus. Dieses Zitat ist gerade jetzt aktuell. Der Tierarzt ist
+sehr gut. Die alte Stadt lag tiefer als der See. Das
+Zertifikat ist zu alt.</text>
+  </lesson>
+  <lesson>
+   <id>{880840fd-4798-4dc3-9a5e-2b0e3addfc66}</id>
+   <title>v und m</title>
+   <newCharacters>vmVM</newCharacters>
+   <text>frf fvf fvf fvf fvö fvl fvk fvj fva fvs fvd fvf fvd fvs fvs
+viel viel viel vier vier vier viel viel vier vier viel viele
+verlas verlas verlas versah versah verlas verfasse verliere
+verzeiht verzeiht verkehrt verkehrt verödet verödet verödet
+verzagte verzagte verzagte verhörte verhört verhört verdaut
+aktiv aktiver aktiver aktiver relativ relativ relativ aktiv
+Vieh Vieh Vieh Vati Vati Vati Vieh Vieh Vati Vati Vieh Verse
+juj jmj jmj jmj jma jms jmd jmf jmö jml jmk jmj jmö jml jmk
+dem dem dem kam kam kam mag mag mag dem dem kam kam mag mag
+mir mir mir arm arm arm mit mit mit mir mir arm arm mit mit
+mehr mehr mild mild male male mehr mild male male mild mehr
+merke merke immer immer fremd fremd merke immer fremd merke
+filme filme emsig emsig mager mager filme emsig mager filme
+vermeide vermeide vermerke vermerke vermeide vermerke jedem
+vermehrt vermehrt vermehrt verfilme verfilme verfilme milde
+Meer Meer Meer Mark Mark Mark Meer Meer Mark Mark Meer Makel
+Turm Turm Turm Darm Darm Darm Turm Turm Darm Darm Turm Musik
+verfiel immer mehr, verlief immer mild, verriet heute immer
+mehr, vieles ist gefilmt, vielerlei merkt er, er vermittelte
+mir alles, vermittle es heute, sie verliert heute, höre
+jetzt aufmerksam zu.</text>
+  </lesson>
+  <lesson>
+   <id>{3f3ead31-367f-4a7b-9ae4-a58e99ae632d}</id>
+   <title>v und m (2)</title>
+   <newCharacters></newCharacters>
+   <text>hier malt er emsig, du vermittelst das, sie ist hier völlig
+fremd, merke dir dies gut, verkaufe das heute, verleihe das
+alles heute, er hat das gemerkt, er verkaufte alles, sie
+verliest jetzt alles, melde es mir heute, melde es ihm,
+melde es heute, meldet es jetzt lies aufmerksam, lies immer
+aufmerksam, leite es jetzt aufmerksam vermittle es,
+vermittle es ihm, vermeide das, vermeide dies heute er
+vermag es, dies ist relativ, er verteilte meist alles sehr
+gut dies ist seltsam, dies alles ist sehr seltsam, verleihe
+es heute, hier verkauft er viel, sie verkaufte hier mehr,
+das mag er jetzt, sie vermittelt es, sie vermittelte es
+mehrmals, merke dir das gut er merkt alles, er vermerkte das
+meiste, sie verlieh heute alles, die Villa, der Makel, die
+Vögel, die Mitte, der Vikar, die Messe, im Verhör, im
+Verlag, im Verzug, im Visier, im Verrat, im Verzug, mit
+Maske, mit Marke, mit Visum, mit Musik, mit Miete, mit
+Timer, am Freitag, am Samstag, am Feiertag, am Markttag,
+erst am Mittag, um Ulm herum, um die Mauer, um die Miete, um
+mehr Ruhe, der Raum, zum Mahl, zum Verkauf, zum Verzehr, zum
+Verleger, zum Mittelmeer, Mittags ist er damit fertig. Eva
+sagt, dass sie Fehler vermeidet. Der Vertreter kam aus
+Jever. Im Vierteljahr zahlt sie mehr Miete. Der Sieger hat
+tief geatmet. Du sagst, dass es ihm ums Geld geht. Erst
+jetzt kam der Missgriff heraus. Das missfiel jedem Mitglied.
+Sie hatte die Miete im Juli gezahlt. Der Verleger las
+aufmerksam. Mir missfiel der materielle Verlust. Herr Veit
+Maus ist verreist. Die Madrider Firma teilt mir mit, dass
+sie am Freitag ausliefert. Der Umsatz des Trierer
+Stadtvertreters ist jetzt stark reduziert. Im August hat
+Frau Eva Zimmer das alte Gasthaus am See vermietet. Leider
+reklamierte die Krefelder Firma die Artikel aus Karlsruhe.</text>
+  </lesson>
+  <lesson>
+   <id>{0a340ea0-c10f-40c1-b4a5-6493e8420e94}</id>
+   <title>b und n</title>
+   <newCharacters>bnBN</newCharacters>
+   <text>fvf fbf fbf fbf fbö fbl fbk fbj fvf fbf fbd fbs fba fbs fbd
+bis bis bis bei bei bei bis bis bis bei bei bis bis bei bis
+beim beim halb halb aber aber bald bald beim halb aber halbe
+fbfrf fbfr fbr bri briet briet breit breit brav brav brave
+frfbf frfb frb arb arbeite arbeite arbeitet verdarb verdarb
+fbftf fbft fbt ibt gibt gibt gibt lebt lebt lebt labt lebte
+jmj jnj jnj jnj jna jns jnd jnf jnö jnl jnk jnj njö jnl njk
+den den den ein ein ein neu neu neu den den ein ein neu eine
+sein sein kein kein lang lang mein mein sein kein lang seine
+allen allen gegen gegen einen einen allen gegen einen allen
+gegen gehen gehen dient dient ihren ihren gehen dient ihren
+gehen dient sagen sagen sehen sehen keine keine sagen sehen
+keine sagen sehen geben geben geben haben haben haben geben
+geben haben haben geben neben neben neben leben leben leben
+neben neben leben leben neben binden binden binden darben
+darben darben binden darben mag binde antik antik antik
+beige beige beige antik antik beige beige antik unfair beige
+genial genial genial unfair genial unfair abstrakt abstrakt
+abstrakt basieren basieren basieren abstrakt ab Nase Nase
+Nase Name Name Name Nerv Nerv Nerv Nase Name Nerv Namen
+sie halten nun immer daran fest, sie halten nun immer daran
+fest, er behandelt es als eilig, sie behandeln es heute als
+sehr eilig, sie dankten, sie bieten, sie sehen es ein, sie
+bitten jetzt darum</text>
+  </lesson>
+  <lesson>
+   <id>{3bae2245-c934-41e7-a505-639317326185}</id>
+   <title>b und n (2)</title>
+   <newCharacters></newCharacters>
+   <text>sie senden, sie geben, sie kennen, sie beten, sie behandelte
+es, sie können es, sie kann viel, sie könnten es aber heute
+verlieren jetzt bitten sie darum, jetzt hört sie, jetzt
+lernen sie es aber, er arbeitet mit, sie arbeitet mit, alle
+arbeiten jetzt immer mit, er diktiert gut, sie diktiert gut,
+alle diktieren jetzt aber gut, er behandelt es, er behandelt
+es, alle behandeln es jetzt eilig, er lernt eifrig, sie
+lernt eifrig, alle lernen jetzt aber eifrig, der Baum, der
+Neid, der Ball, das Netz, das Blut, der Niedergang. Der
+Brei, die Nuss, das Blei, der Narr, die Burg, in den Bergen,
+die Entfernung. In den Burgen, in den Beeten, am Dienstag
+und am Freitag, in den Niederlanden. An unserem Jahrestag,
+an diesem Abend an den Feiertagen, an den Festtagen, an den
+beiden letzten Tagen, aus Rand und Band, auf der Bank, beim
+Bund, beim Brand in Bremen. Bald können Sie in Köln bauen.
+Die Zimmer in Augsburg sind teuer. Die Messe findet in Ulm
+statt. Das Muster fand lebhaften Beifall. Ute hat erst
+einmal angerufen. Ihr Aufenthalt geht jetzt zu Ende.
+Sie kennen unsere Bedingungen. Bitte bringen Sie alle Bilder
+mit. Der Kunde bezahlte den Betrag. Unser Treffen findet im
+Mai statt. Ihre Einnahmen sind zu gering. In Zukunft gibt es
+mehr Verdienst. Unsere Kunden zeigen viel Interesse an der
+Ausstellung in Berlin. Sie sind der Meinung, dass unsere
+Ausstellung viel geleistet hat. Der Messestand der Firma
+Steinmann fand sehr viel Aufmerksamkeit. Mit dem Umsatz sind
+aber alle Unternehmen diesmal sehr zufrieden.</text>
+  </lesson>
+  <lesson>
+   <id>{132051c4-49c6-4258-8962-bb6227d1b0a9}</id>
+   <title>c und ;</title>
+   <newCharacters>c;C</newCharacters>
+   <text>fvf jmj k,k dcd dcd dcd dcö dcl dck dcj dcd dca dcs dcf ded
+auch auch dich dich mich mich sich sich auch dich mich dicht
+durch durch nicht nicht macht macht durch nicht macht durch
+Dach Dach Tuch Tuch Buch Buch Fach Fach Dach Tuch Facharbeit
+Heck Heck Ecke Ecke Leck Leck Heck Heck Leck Leck Eckschrank
+Chef Chef Club Club Cent Cent Chef Chef Club Club Clubzimmer
+jmj k,k k;k k;k k;k k;a k;s k;d k;f k,k k;k k;ö k;l k;j k,k
+Leib, Laib; Seite, Saite; Meier, Maier; Leib, Laib; Saite;
+Sie schreibt auf einer Maschine; darum arbeitet sie sehr
+schnell. Auch Sie möchten vieles leisten; deshalb teilen Sie
+die Zeit ein. Alle möchten ihr Ziel erreichen; darum
+trainieren sie auch heute. Er sagt, das Buch sei lehrreich;
+darum möchte ich es jetzt lesen. fleckig, fleckig; dreckig,
+dreckig; stickig, stickig; vierstöckig ehrlich, ehrlich;
+amtlich, amtlich; redlich, redlich; namentlich;
+indisch, indisch; römisch, römisch; badisch, badisch;
+griechisch; unter Chiffre, die Caritas, das Chinin, die
+Chemie, der Chemiker; nach Celle fahren, bald nach Chemnitz
+fahren, nach China fliegen; die gute Eigenschaft, die feine
+Gesellschaft, diese Freundschaft;</text>
+  </lesson>
+  <lesson>
+   <id>{86ee2b50-5963-4467-829d-f64a4c3f18ff}</id>
+   <title>c und ; (2)</title>
+   <newCharacters></newCharacters>
+   <text>Mich interessiert die Chance, die mir die Stelle in Celle
+bietet. Bei der chemischen Fabrik in Ulm hatte ich kaum
+Aufstiegschancen. Die Firma Dietrich Christ bietet mir einen
+neuen Aufgabenbereich. Jeden Tag lesen und hören Sie
+Nachrichten aus Deutschland und den anderen Staaten.
+Zeitungen und technische Medien bringen aktuelle Berichte;
+sie halten uns auf dem Laufenden und dies ist sehr gut. Die
+Schrift hat eine lange Geschichte. An ihrem Anfang stehen
+die Höhlenzeichnungen und Bilderschriften. Dann kamen
+Silbenschriften auf. Aber erst die Buchstabenschrift brachte
+Vereinfachungen; sie gibt allen die Chance, dass sie das
+Lesen und Schreiben erlernen.</text>
+  </lesson>
+  <lesson>
+   <id>{0848f1db-321a-4bc2-8653-3a74a5916b18}</id>
+   <title>w und o</title>
+   <newCharacters>woWO</newCharacters>
+   <text>frf ded sws sws sws swö swl swk swf swd swa sws swf swd swa
+wir wir wir wen wen wen wie wie wie wir wir wen wen wie wie
+wird wird wird wann wann wann wenn wenn wenn wird wann wurde
+warum warum warum etwas etwas etwas warum warum etwas warum
+Wagen Wagen Wagen Wette Wette Wette Wagen Wagen Wette Wagen
+Zwang Zwang Zwang Zweck Zweck Zweck Zweig Zweig Zweig Zwang
+juj kik lol lol loa los lod loj lok lol loö loj lok loö loj
+vor vor vor von von von los los los vor vor von von los los
+noch noch noch doch doch doch oder oder oder noch noch noch.
+Ton Ton Ton Lob Lob Lob Not Not Not Ton Ton Lob Lob Not Not
+Obst Obst Obst Ofen Ofen Ofen Orte Orte Orte Obst Obst Ochse
+Lord Lord Lord Gong Gong Gong Gott Gott Gott Lord Gong Lotto
+vornehmen vorkommen vorsehen vorlegen vorwerfen vorstellen
+vorige wertlos witzlos ehrlos haltlos wahllos sorglos
+glanzlos schlaflos Widerhall Widerrede Widerstand
+Wiedersehen, Wiederholungsabschnitt, Am Sonntag, am Montag,
+am Mittwoch, am Donnerstag, bis Sonnabend; Motorradbrillen
+Motorrennen Motorhaube Motorenbau Motorfahrzeuge; die Nation
+die Funktion, im Stadion, die Information, die Union;</text>
+  </lesson>
+  <lesson>
+   <id>{9e3790f0-1184-47e6-b0d4-7e407c356aec}</id>
+   <title>w und o (2)</title>
+   <newCharacters></newCharacters>
+   <text>Der Sonderzug wird am kommenden Donnerstag in Hamborn
+eintreffen. Die Ortsdurchfahrt in Gotha wurde am Mittwoch
+wieder freigegeben. Die Wohnungsnot in Dortmund hat sich im
+Oktober etwas vermindert. Das Konzert des Bonner Orchesters
+war wiederum ein voller Erfolg. Das Wörterbuch sagt im
+Vorwort manches zur neuen Rechtschreibung. Zwischen Oekonomie
+und Oekologie muss ein Einklang gefunden werden. Die
+Geschichte der Weltraumfahrt ist noch gar nicht so alt.
+Schon in relativ kurzer Zeit erforschten die Astronauten den
+Mond sowie vieles im Weltall. Von besonderem Wert ist jedoch
+die Erforschung des Wetters durch Satelliten; die
+Wettervorhersage wurde genauer.</text>
+  </lesson>
+  <lesson>
+   <id>{734e9ce2-5f5a-4df8-a1de-2ccc5bccb14c}</id>
+   <title>q und p</title>
+   <newCharacters>qpQP</newCharacters>
+   <text>frf ded sws aqa aqa aqa aqö aql aqk aqj aqa aqs aqd aqf aqa
+qui qui qui quo quo qui qua qua qua que que que qui quo qua
+quick quick quick quoll quoll quoll quick quick quoll quoll
+Quiz Quiz Quiz Qual Qual Qual Quai Quai Quai Quiz Qual Quai
+Quote Quote Quote Queen Queen Queen Quote Quote Queen Queen
+die Quelle, die Quelle, die Clique, das Cliquenwesen,
+juj kik lol öpö öpö öpö öpa öps öpd öpö öpj öpk öpl öpj öpk
+per per per pur pur pur per per pur pur per per pur pur per
+knapp knapp knapp spitz spitz spitz super super super knapp
+Kopf Kopf Kopf Topf Topf Topf Oper Oper Oper Kopf Topf Suppe
+Paar Paar Paar Post Post Post Polo Polo Polo Paar Post Paket
+Pflanze Pflanze Pfarrer Pfarrer Pfeffer Pflanze September
+Querschnitt Querschlag Querkopf Querdenker Quersummen
+der Querulant, die Qualifikation, die Apothekerin, die
+Diplomaten, das Programm, das Protokoll, der Pullover, der
+Optiker in Passau, das Papier, die Papierfabrik, der
+Papierkorb, die Papierserviette. Das Fotopapier, das
+Kopierpapier, das Aquarellpapier aus Cottbus, der Sport, die
+Sportlerin, die Sportartikel, nur beim Motorsport.</text>
+  </lesson>
+  <lesson>
+   <id>{6aa6d042-32ea-4526-96ee-093129b5abb9}</id>
+   <title>q und p (2)</title>
+   <newCharacters></newCharacters>
+   <text>Jetzt soll am Kurpark ein neuer Kinderspielplatz angelegt
+werden. Die Vorarbeiten haben Pauline Quade und Peter Pelzer
+organisiert. Nach Pressemeldungen beginnen die Bauarbeiten
+schon im September. Die Polizei hat mehrere Aufgaben.
+Deshalb ist die Polizei in zwei Hauptabteilungen gegliedert.
+So gibt es neben der Vollzugspolizei eine Kriminalpolizei.
+Diese Hauptabteilungen bilden Untergruppen. Unser
+Quadlinburger Zweigwerk sucht eine Auslandskorrespondentin.
+Die Bewerberin muss Englisch, Spanisch sowie Russisch in
+Wort und Schrift beherrschen. Ferner soll Sie mit den
+Arbeiten am Computer vertraut sein. Die Stelle kann schon im
+September besetzt werden.</text>
+  </lesson>
+  <lesson>
+   <id>{40bccf77-1e23-4830-886c-5e9185dc7bb4}</id>
+   <title>ä</title>
+   <newCharacters>ä</newCharacters>
+   <text>fgf öäö öäö öäö öäf öäd öäs öäa fgf öäö öäj öäk öäl öäj öäk
+fö fä jö jä dö dä kö kä sö sä lö lä tö tä zö zä mö mä nö nä
+spät spät spät wäre wäre wäre läge läge läge spät wäre kläre
+kämen kämen nähme nähme nähme nähen nähen hätte prägt nähen
+Wärme Wärme Wärme Bäume Bäume Bäume Bälle Bälle Bälle Wärme
+Käufe Käufe Käufe Räder Räder Räder Sätze Sätze Sätze Käufe
+Bände Bände Bände Zähne Zähne Zähne Länge Länge Länge Bände
+die Hautärzte, die Zahnärzte, die Fachärzte
+regulär regulär primär primär sekundär sekundär legendär
+Sekretäre, Sekretäre; Militär; Sekretärin, Sekretärinnen
+Qualität, Qualität; Quantität; Naivität, Kriminalität;
+Das Protokoll sollte in der Gegenwart, im Präsens abgefasst
+sein. Präpositionen sind Verhältniswörter, z. B. an, am, in,
+bei, vorn. Der Pädagoge ist ein Erzieher; er arbeitet z. B.
+in einer Schule. Prädikat kann man meist mit Bewertung,
+Note, Zensur verdeutschen. Die Bundestagspräsidentin hat
+auch die gestrige Sitzung eröffnet. Der Leiter einer
+Organisation wird sehr häufig Präsident genannt. Die
+städtischen Plätze sind sorgfältig zu pflegen. Man denke
+etwa an Sportplätze, Festplätze, Rastplätze, Liegeplätze,
+Halteplätze, Tennisplätze usw. Die Bauplätze sind aber
+zugleich Arbeitsplätze. Sehr geehrte Frau Schäfer, Ihre
+Bewerbung als Sekretärin unserer Rostocker Niederlassung
+gefällt uns. Zu Ihren Aufgaben zählt die Betreuung
+ausländischer Arbeitnehmer. Wir hoffen, dass Sie diese
+und die anderen einschlägigen Tätigkeiten sorgfältig
+wahrnehmen.</text>
+  </lesson>
+  <lesson>
+   <id>{4b142afd-0251-409d-b038-4624defdf14c}</id>
+   <title>x und :</title>
+   <newCharacters>x:X</newCharacters>
+   <text>fvf dcd sxs sxs sxs sxö sxl sxk sxs sxf sxd sxa sxs sxa sxd
+oxs oxs ixs ixs exs exs axs axs oxs oxs ixs ixs exs exs axs
+boxen boxen boxen hexen hexen hexen boxen boxen hexen hexen
+mixen mixen mixen extra extra extra mixen mixen extra extra
+Texte Texte Texte Luxus Luxus Luxus Texte Texte Luxus Luxus
+Lexika Lexika Examen Examen Examen Lexika, im Staatsexamen
+jmj k,k l.l l:l l:l l:l l:a l:d l:s l:f l:l l:ö l:k l:j l:l
+Städte: in Xanten, in Cuxhafen, in Luxemburg; Mexiko,
+Alexandria; Vornamen: Max, Maximilian, Felix, Alex, Xaver;
+Frau Xenia Saxler; Beispiel: Exempel; Versuch: Experiment;
+Sachverständiger: Experte; Verbannungsort: Exil; Ausfuhr:
+Export; Ausdehnung: die Expansion; Börsenkurs: Exchange;
+Studienfahrt: Exkursion, Gegenteil: Extrem; Text, Texte,
+Textprogramme, Textbearbeitung, die Textverarbeitung, Urtext
+und Kontext, Klartext, Begleittext, Originaltext,
+Werbetexte, Textilien, Textilwaren, Textilgeschäft,
+Textilchemie, Textilindustrie</text>
+  </lesson>
+  <lesson>
+   <id>{f14f1edc-6508-484e-9734-f6ed57b91a10}</id>
+   <title>x und : (2)</title>
+   <newCharacters></newCharacters>
+   <text>Die Textilfabrik Felix Luxem exportierte Textilwaren nach
+Mexiko. In den neuen Lexikonbänden sind alle Informationen
+exakt erfasst. Alexander Hox hat sich in Luxemburg eine neue
+Existenz aufgebaut. Auch im Exportgeschäft hat sich Telex
+als unverzichtbar erwiesen. Aber auch die Telefaxverbindung
+hat sich inzwischen sehr bewährt. Der Werbetexter des
+Lexikonverlags ist auf seinem Gebiet Experte. Dr. Alex Fox
+hat am Maximilianplatz eine Zahnarztpraxis eröffnet. Dagegen
+wurde die Praxis von Dr. Luxem in die Hexengasse verlegt.
+Die Arztpraxen werden auch von externen Patienten sehr
+geschätzt. Sehr geehrter Herr Lexter, soeben haben wir Ihr
+Telefax erhalten. Ihre exakten Angaben sind sehr wertvoll.
+Maximal wollen wir jetzt sechs exklusive Exportmodelle
+bauen. Gewiss ist dieses Experiment gewagt. Jedoch erwarten
+wir eine Expansion unserer Exportanteile.</text>
+  </lesson>
+  <lesson>
+   <id>{c1361456-8d2e-41e9-b926-31f4bbc9dedf}</id>
+   <title>ü</title>
+   <newCharacters>ü</newCharacters>
+   <text>ftf öüö öüö öüö öüa öüs öüd öüf öüö öüj öük öül ftf öüö öüj
+über über über üben üben üben kühl kühl kühl über üben kühl
+früh früh früh müde müde müde wüst wüst wüst früh müde frühe
+Düse Düse Düse Hüte Hüte Hüte Tüte Tüte Tüte Düse Hüte Düsen
+Züge Züge Züge Rüge Rüge Rüge Züge Dünen
+Flüge Flüge Flüge Küche Küche Küche Flüge
+überall, übernimmt, überhört, übersetzt, überfüllt,
+Rücksicht, Rückfahrt, Rückgänge,
+Rückkehr, Rückzüge, Rückschläge, Glücksfall, Glücksrad,
+Glückszahl, Glückssache, Glückwunschkarte, zurückkommen,
+zurück, zurückdrehen, zurückdrängen, zurückgesetzt,
+Konfitüre, Maniküre, Pediküre, Broschüren, Allüren,
+Reiselektüre.</text>
+  </lesson>
+  <lesson>
+   <id>{57a4a2a3-8128-421a-94c2-7ba997413d22}</id>
+   <title>ü (2)</title>
+   <newCharacters></newCharacters>
+   <text>Die Konfitürenfabrik hat Filialen in München, Fürth und
+Tübingen. Für die Fahrt von Düsseldorf nach Zürich kaufte
+ich Reiselektüre. Zum Glück kamen sämtliche Sonderzüge
+wieder überaus pünktlich an. Das Lüdenscheider Werk
+exportiert auch Kühlschränke nach Brüssel. Die Düsseldorfer
+Zentrale wünscht wieder ausführliche Broschüren. Der
+Lübecker Werbetexter formulierte auch zündende
+Ueberschriften. Arbeit gibt es in der Fabrik glücklicherweise
+in Hülle und Fülle. Wir dürfen auf Ihre Vorschläge für
+unsere Uebersicht zurückkommen. Sie wünschen, dass in dieser
+Uebersicht alle Flüge erfasst werden. Sie dürfen nun
+überzeugt sein, dass wir die Mängelrüge sorgfältig prüfen.
+Natürlich übernehmen wir für die Qualität der Textilwaren
+volle Garantie. Die Mängelrüge wird aber unverzüglich
+bearbeitet. Wir alle müssen im Leben Prüfungen ablegen. Die
+Prüfungsangst ist weit verbreitet, aber in Prüfungen
+natürlich wenig nützlich. Wenn Sie sich früh genug und
+gründlich vorbereiten, haben Sie günstige Voraussetzungen
+geschaffen. Gehen Sie dann ruhig in Ihre Prüfung.</text>
+  </lesson>
+  <lesson>
+   <id>{54cc9e1b-e365-4a47-9b54-c2f817be5bbb}</id>
+   <title>y und -</title>
+   <newCharacters>y-Y</newCharacters>
+   <text>frf dcd sxs aya aya aya ayö ayl ayk aya ayf ayd ays aya ayf
+sys sys sys rhy rhy rhy zyl zyl zyl bay bay bay hyg hyg hyg
+may may may say say say you you you may may say say you you
+Typ Typ Typ Boy Boy Boy Roy Roy Roy Typ Typ Boy Boy Roy Roy
+Jury Jury Jury City City City Baby Baby Baby Jury City Party
+Okay Okay Okay Yard Yard Yard Yoga Yoga Yoga Okay Yard Handy
+jmj k,k l.l ö-ö ö-ö ö-ö ö-f ö-d ö-s ö-a ö-ö ö-j ö-k ö-l ö-ö
+S-Kurve S-Kurve S-Kurve i-Punkt i-Punkt i-Punkt S-Kurve
+T-Träger; Dativ-e Dativ-e Dativ-e Fugen-s Fugen-s Fugen-s
+Dativ-e s-förmig; Kfz-Papiere, Kfz-Papiere, Fussball-WM,
+Kfz-Werkstätten in der Paul-Klee-Strasse, im Dr.-Mayer-Weg,
+der Pfarrer-Kneipp-Weg, An- und Abfahrt, Vor- und Zunamen,
+dieser Haupt- und Nebeneingang
+Ha- ken, La- ger, Ei- fer, A- bend, El- tern, Far- ben,
+Emp- fang, Ha- cke, E- cken, Lü- cke, Ho- cke, Bu- ckel,
+Dru- cke, Bli- cke, Res- te, Lis- te, Hus- ten, Las- ter,
+Kos- ten, Bas- tel- freund, an- grenzen, be- freit, ver-
+blendet, ge- tragen, über- ängstlich, Zur Wahl: he- ran oder
+her- an, da- raus oder dar- aus, wo- rüber oder wor- über;
+pub- lik oder pu- blik, Sig- nale oder Si- gnale</text>
+  </lesson>
+  <lesson>
+   <id>{f23f798f-bc75-4a65-92c4-972c8f245e78}</id>
+   <title>y und - (2)</title>
+   <newCharacters></newCharacters>
+   <text>Unsere Analyse ergab zum Glück keine hygienischen Beanstan-
+dungen. Mit dem gleichen System haben wir das Recyclingpa-
+pier analysiert. Dieses synthetische Verfahren hat sich in
+Speyer bereits bewährt. Die Jury hat die rhythmische Gymnas-
+tik von Sybille hoch bewertet. Erst im Play-Back konnte
+Trainer Freddy alle Feinheiten erkennen. Auch Gaby und Nelly
+interessieren sich für rhythmische Gymnastik. Krankengymnas-
+tik gehört zum medizinischen Fachgebiet der Physika- lischen
+Therapie. Physiotherapeuten stellen anhand der ärztlichen
+Diagnose einen Therapieplan auf. Physiotherapeuten arbeiten
+z. B. in Kliniken, Sanatorien, Erholungsheimen sowie in
+Facharztpraxen.</text>
+  </lesson>
+  <lesson>
+   <id>{6fd2d8ae-6371-428b-9df9-b92e3a9bc591}</id>
+   <title>_ und ?</title>
+   <newCharacters>_?</newCharacters>
+   <text>ö-ö ö_ö ö_ö ö_ö ö_a ö_s ö_d ö_f ö-ö ö_ö ö_j ö_k ö_l ö_ö ö-ö
+Der Name ist uns nicht bekannt. Wir haben ihn noch nicht er-
+fasst. Dr. Schäfer fliegt nach Sydney. Wir treffen ihn also
+am Mittwoch. Am Montag hat unsere Zentrale mehrere Stellen-
+anzeigen aufgegeben. Auf diese Annonce haben sich bisher
+vier Interessenten gemeldet. Frau Rita Berghöfer, Merseburg,
+wurde in die engere Wahl gezogen.
+ö_ö ö?ö ö?ö ö?ö ö?a ö?s ö?d ö?f ö_ö ö?ö ö?j ö?k ö?l ö?ö ö?j
+Wie? Wie? Wie? Wer? Wer? Wer? Was? Was? Was? Wie? Wer? Wann?
+Wann fliegen Sie nach New York? Wie lange möchten Sie weg-
+bleiben? Kennen Sie schon unser modernes Textsystem für Phy-
+siotherapeuten? Wann darf Ihnen unsere Mitarbeiterin dieses
+Textsystem vorführen? Oder wollen Sie das Textsystem lieber
+in unserem Geschäft testen? Hat Ihnen unsere letzte Lief-
+erung missfallen? Hatten Sie sich die Ausführung anders
+vorgestellt? Kam die Sendung vielleicht beschädigt an? Oder
+gibt es sogar noch andere Gründe für Ihr Schweigen?</text>
+  </lesson>
+  <lesson>
+   <id>{14b1df70-ac60-46c9-82fe-0af17d43ba3f}</id>
+   <title>_ und ? (2)</title>
+   <newCharacters></newCharacters>
+   <text>In Ihrem Reisebericht ist Ihnen leider ein Irrtum unterlau-
+fen. Es scheint sich um eine Verwechslung der Firma Ewald
+Meyer in Aachen mit der Lack- und Farbenfabrik Ewald Meyer
+in Krefeld zu handeln. Ist Ihnen bewusst, dass Informatikas-
+sistenten und -assistentinnen über solide Qualifikationen
+verfügen müssen? Kennen Sie schon die Anforderungen im Ein-
+zelnen? Lesen Sie unser Informationsmaterial? Was verstehen
+Sie unter Systemanalyse? Sind Ihnen die Fachausdrü- cke Op-
+timierung von Software oder Erstellung von Programmdokumen-
+tationen ein Begriff? Haben Sie unsere Infos bereits ange-
+fordert? Telefonieren Sie richtig? Verhalten Sie sich dem
+Gesprächspartner gegenüber freundlich und zuvorkommend?
+Sprechen Sie verständlich? Ist Ihre Tonlage angenehm? Berei-
+ten Sie Ihre Telefonate vor? Kön- nen Sie richtig buchsta-
+bieren? Kennen Sie alle Buchstabierwörter?</text>
+  </lesson>
+  <lesson>
+   <id>{559c52d2-5f49-4e01-92ab-6c4ad4be14a7}</id>
+   <title>Uebung 1</title>
+   <newCharacters></newCharacters>
+   <text>abc def ghi jkl mno pqr stu vwx yzä öü abc def ghi jkl mno
+die der und den das von sie ist des mit dem ein ich auf aus
+als wie für man aus nur war bei hat wir mir was ihm uns zum
+Bau Ast Ort Tal Mal Ton Zug Amt Tür See Tor Rat Mut Mai Tat
+Unser Mitarbeiter Herr Lay ist heute Morgen nach Dessau ge-
+fahren. Bereits gestern Abend hat er seinen Pkw mit Dekoma-
+terial beladen. Mit dem Besuch der Kunden müsste Herr Lay
+morgen Mittag beginnen. Am Freitagmorgen müsste das Erdge-
+schoss bereits zu beziehen sein. Dann könnte man das neue
+Fachgeschäft donnerstagabends einräumen. Die Vorbereitungen
+müssten aber schon mittwochs getroffen werden. Auch er weiss,
+dass die Kassette ein bisschen teurer geworden ist. Der
+grosse Fluss muss in seinem Lauf einige Nebenflüsse aufneh-
+men. Beim Abriss dieses alten Hauses können die Stützen
+leicht reissen. Wusste er, dass der Stress mit Gelassenheit
+abgebaut werden kann? Dass dieses Buch so interessant war,
+das vergisst gewiss niemand. Ich glaube, dass das Buch, das
+Sie gestern kauften, spannend ist. Zur Wahl: Wann findet die
+Abschlusssitzung des Ausschusses statt? Oder: Die Abschluss-
+Sitzung soll doch erst im August stattfinden. Bei niedrigem
+Wasserstand kann die Schiff-Fahrt nicht voll laden. Die
+Schnell-Läuferin hatte auf dem Rücken eine grosse Kenn-
+Nummer. Gestern Mittag haben wir im Zoo die grossen See-Ele-
+fanten gefilmt. Die Zeitungen berichten über eine schlechte
+Tee-Ernte in Uebersee.</text>
+  </lesson>
+  <lesson>
+   <id>{a49777c2-826b-46e8-9013-a609f03d6d6a}</id>
+   <title>Uebung 2</title>
+   <newCharacters></newCharacters>
+   <text>abcd efgh ijkl mnop jqrst uvwx yzöä öüö abcd efgh ijkl mop
+wenn aber sein mein dein kein wird hast gibt sagt denn legt
+keine sind sich dass nach noch doch beim oder über sehr will
+hier durch Wald Bank Erde Lied Kind Buch Wort Zorn Juni Geld
+Im Grossen und Ganzen werden Sie stets auf dem Laufenden ge-
+halten. Ueber Folgendes müssten sich aber alle Mitarbeiter im
+Klaren sein: Es ist uns bekannt, dass Dr. Stein im Allge-
+meinen am Alten hängt. Wer ist schuld daran, dass die Firma
+Schäfer Pleite gegangen ist? Die Firma Schäfer ist pleite;
+daran trägt Dr. Klein keine Schuld. Wir müssen Verluste
+ernst nehmen, damit wird jetzt Ernst gemacht.</text>
+  </lesson>
+  <lesson>
+   <id>{d70d295e-c2bc-440c-a9c8-8a986b364b03}</id>
+   <title>4 und $</title>
+   <newCharacters>4$</newCharacters>
+   <text>ded d4d d4d d4d d4ö d4l d4k d4j d4d d4a d4s d4f d4d d4a d4s
+4 Daten, 4 Autos, 4 Stück, 4 Jahre, 4 Daten, 4 Scheiben,
+ded d4d d$d d$d d4d d$d d$d d4d d$d, für 4 $, für 44 $, 44 $</text>
+  </lesson>
+  <lesson>
+   <id>{80eda0dc-725e-4b23-9f57-a3dbf951f26a}</id>
+   <title>9 und )</title>
+   <newCharacters>9)</newCharacters>
+   <text>kik k9k k9k k9k k9a k9s k9d k9f k9k k9ö k9l k9j k9ö k9l k9j
+9 Kegel, 9 Oefen, 9 Kegel, 9 Oefen, 9 Kegel, 9 Oefen, 9 km,
+k9k k)k k)k k)k k)ö k)l k)j k9k k)k a) b) c) d) e) f) g) h)</text>
+  </lesson>
+  <lesson>
+   <id>{47a22dd2-9e49-4980-a688-fd5eee990496}</id>
+   <title>5 und %</title>
+   <newCharacters>5%</newCharacters>
+   <text>ded d4d frf f5f f5ö f5l f5k f5j f5f f5a f5s f5d f5f d4d f5f
+5 Filme, 5 Arten, 5 Fälle, 5 Augen, 5 Filme, 4 Filme, 5 km,
+d4d d$d f5f f%f f%f f%f f%a f%s, 5 %, 5 % Verlust, 5%iger</text>
+  </lesson>
+  <lesson>
+   <id>{04a41835-cf98-412e-aaa9-0f47f9e63edc}</id>
+   <title>8 und (</title>
+   <newCharacters>8(</newCharacters>
+   <text>kik k9k juj j8j j8j j8j j8a j8s j8d j8f j8j j8ö j8l j8k j8j
+8 Jahre, 8 Oesen, 8 Jäger, 8 Oefen, 8 Jeeps, 8 Jeeps, 88 km,
+j8j j(j j(j j(ö j(l j(k), Frankfurt (Main), Frankfurt (Oder)</text>
+  </lesson>
+  <lesson>
+   <id>{58881cf4-4826-40da-bedd-e566dd962fa7}</id>
+   <title>Uebung</title>
+   <newCharacters></newCharacters>
+   <text>Das 4-stöckige Gebäude wurde schon am 5. Oktober fertig
+gestellt. Um 5 % hat sich der Jahresumsatz der Ravensburger
+Filiale erhöht. Mit der 5%igen Umsatzsteigerung hatte der
+Filialleiter gerechnet. Der 49-jährige Angestellte leitet
+die Filiale in Koblenz (Rhein). In Konstanz findet vom 8.
+bis 9. Oktober ein Aerztekongress statt. Frau Eva Mayer
+(Sulzberg) bereist den Bezirk Freiburg (Breisgau). Die Firma
+Schneider (Köln) konnte den Artikel für 49 $ einkaufen. Der
+neue 8-Zylinder-Motor zeichnet sich durch grosse Laufruhe
+aus. Der Neubau Heidelberger Strasse 58 a könnte im Mai
+bezogen werden.</text>
+  </lesson>
+  <lesson>
+   <id>{539d8c54-7c9a-4a26-a09d-98f4e00a7d9b}</id>
+   <title>6 und &amp;</title>
+   <newCharacters>6&amp;</newCharacters>
+   <text>frf f5f ftf f6f f6f f6f f6ö f6l f6k f6f f5f f6f f6a f6s f6d
+6 Filme, 6 Gänge, 6 Arten, 6 Stäbe, 5 Gänge, 4 Gänge, 6 Züge
+f6f f&amp;f f&amp;f f&amp;ö f&amp;l f&amp;k f&amp;j; Ruf &amp; May, Tal &amp; Roy, Zug &amp; Rat</text>
+  </lesson>
+  <lesson>
+   <id>{3a7590d9-ef90-4521-869c-bb0a4495bf89}</id>
+   <title>7 und /</title>
+   <newCharacters>7/</newCharacters>
+   <text>juj jzj juj j7j j7j j7j j7a j7s j7d j7f juj jzj j7j j7ö j7l
+7 Uhren, 6 Uhren, 7 Nägel, 8 Nägel, 7 Heime, 8 Haustüren
+j7j j/j j/j j/ö j/l j/k j/j; Typ 49/77, Typ 58/6, Typ 67/89</text>
+  </lesson>
+  <lesson>
+   <id>{e20661b1-7c3c-4b79-8901-aa324296591d}</id>
+   <title>3 und §</title>
+   <newCharacters>3§</newCharacters>
+   <text>f6f f5f d4d s3s s3s s3s s3ö s3l s3k s3j s3s s3f s3d s3a d4d
+3 Dosen, 3 Stück, 3 Arme, 3 Autos, 34 km, 53 km, 63 km, 365
+s3s s§s s§s s§s s§f s§d s§a § 33, § 36, § 37, nach §§ 36-67</text>
+  </lesson>
+  <lesson>
+   <id>{937125e5-b380-4c27-9df1-08dc1db509f1}</id>
+   <title>0 und =</title>
+   <newCharacters>0=</newCharacters>
+   <text>j7j j8j k9k l0l l0l l0l l0a l0s l0d l0f l0l l0j l0k l0ö l0l
+30 Tage, 40 Tage, 50 Tage, 60 Tage, 70 Tage, 80 Tage, in 90
+l0 l=l l=l l=ö l=k l=j; 6 - 3 = 3, 90 - 5 = 85, 70 - 30 = 40</text>
+  </lesson>
+  <lesson>
+   <id>{2ba83c92-d590-4d19-9254-7e5581d89bb2}</id>
+   <title>Uebung</title>
+   <newCharacters></newCharacters>
+   <text>Das Reisebüro in der Max-Planck-Strasse 67 sucht Mitarbeite-
+rinnen. Die Artikel 58, 67, 760 und 800 sind leider nicht
+mehr lieferbar. Die Firma Schäfer &amp; Kaiser AG sucht Mitar-
+beiter/Mitarbeiterinnen. Steiner &amp; Schneider GmbH liefern
+wieder Garten- und Campingmöbel. Ihre Zeitschrift für Juli/
+August/September gefällt mir besonders. Das Geschäftshaus
+Kölner Strasse 33/35 gehört Herrn Peter Fischer. Nun wurde
+§ 3 der Satzung geändert; die §§ 6 und 7 gelten weiter. Alle
+Paragrafen sind wichtig; dies gilt auch für die §§ 6 und 37.
+B = Belgien, E = Spanien, H = Ungarn, R = Rumänien</text>
+  </lesson>
+  <lesson>
+   <id>{a2736949-415e-4ba3-86ba-dc21604ef5fe}</id>
+   <title>2 und "</title>
+   <newCharacters>2 "</newCharacters>
+   <text>f5f d4d s3s a2a a2a a2a a2ö a2l a2k a2j a2a a2f a2d a2s a2a
+2 Autos, 2 Bälle, 2 Werte, 2 Verse, 2 Augen, 2 Bären, 32
+a2 a"a a"a a"f a"d a"s Marke "Roy", Marke "Boy", Marke "Roy"</text>
+  </lesson>
+  <lesson>
+   <id>{8c1d78e9-b81f-46b8-acad-433b6e7c496c}</id>
+   <title>1 und !</title>
+   <newCharacters>1!</newCharacters>
+   <text>f5f d4d s3s a2a a1a a1a a1a a1ö a1l a1l a1k a1j a1a a1f a1d
+1 Arm, 1 Ast, 1 Ass, 1 Arm, 1 Ast, 1 Ass, 10 Arme, 12 Firmen
+a2 a1a a!a a!a a!a Au! Pfui! Ruhe! Gift! Hallo! Hilfe! Stop!</text>
+  </lesson>
+  <lesson>
+   <id>{dc756d8c-46cb-4f4e-901a-af6d9432826b}</id>
+   <title>'</title>
+   <newCharacters>'</newCharacters>
+   <text>ö'ö ö'ö ö'ö ö'j ö'k ö'l - 's ist schade. Das war 'n Riesen-
+erfolg! Die Artikel 10, 20 und 21 können wir von Laurenz'
+Mühle beziehen. Die Firma schreibt: "Das Modell 'London'
+gefällt unseren Kunden." "Wann", fragt Max Braun, "ist das
+Modell 'Rom' wieder lieferbar?" Er sagte: "Der Artikel
+'Kairo' soll in 'Paris' umbenannt werden." Sehr geehrte
+Damen und Herren! Für Ihre Anfrage danken wir Ihnen. Sehr
+geehrte Damen und Herren, für Ihre Anfrage danken wir Ihnen.
+Unsere Werbeleiterin meinte: "Wir brauchen einen neuen Pros-
+pekt." "Wie gefällt Ihnen mein Entwurf?", fragte darauf Herr
+Dr. Becker. "Ihr erster Entwurf ist ein Knüller!", meinten
+dann die Kollegen.</text>
+  </lesson>
+  <lesson>
+   <id>{fc0bb71f-b00c-45d2-8c59-462b742a22b9}</id>
+   <title>+ und *</title>
+   <newCharacters>+*</newCharacters>
+   <text>öpö öüö ö+ö ö+ö ö+ö ö+j ö+k ö+l + 1 + 2 + 3 + 4 + 5 + 6 + 70
+ö+ö ö*ö ö*ö ö*j ö*k ö*l ö*ö * 10. Mai, * 19. Mai, * 29. Juni
+Franz X. Wagner * 20. Mai 1837, + 8. März 1907 in New York.</text>
+  </lesson>
+  <lesson>
+   <id>{546b4bc6-bf88-4979-a193-aebf43e42c98}</id>
+   <title>Uebung</title>
+   <newCharacters></newCharacters>
+   <text>nicht durch einen haben einer diese einem hatte seine unter
+schon ihnen meine gegen eines wurde jetzt immer würde alles
+waren recht Namen Leben Recht Macht Seite Liebe Hände Frage
+Augen Vater Jahre Nation Aktion Region Fusion Pension Pas-
+sion Illusionen Navigation Ration Option Legation Version
+Union Stadion Stationen Kreationen Fabrikation Kommunikation
+Demonstration Konfiguration Korporation. Der Aufwand war
+gross. Wir mussten die aufwändigen Ausgaben rügen. Das Stirn-
+band ist rot. Seine Mutter hat ihn immer noch am Bändel. Er
+hat die Schnauze voll. Bruno benahm sich leider grossschnäu-
+zig. Der 22-jährige LKW-Fahrer Max fährt zum x-ten Mal einen
+8-Tonner. Der 8-Zylinder-Motor wurde von der Firma Auto-
+Lange ausgetauscht. Ihre Listen mit 4-silbigen Wörtern sind
+noch nicht 100-prozentig. Der 5 : 3-Sieg unserer Fussball-
+mannschaft war gewiss hochverdient.</text>
+  </lesson>
+ </lessons>
+</course>

--- a/data/courses/ch2.xml
+++ b/data/courses/ch2.xml
@@ -1,0 +1,1171 @@
+<?xml version="1.0"?>
+<course>
+ <id>{90a0ad22-18e7-484f-b1cd-6babdd0f7037}</id>
+ <title>Deutsch (CH - aus Tipptrainer)</title>
+ <description>German training file
+adapted by Sven Gohlke &lt;sven@clio.in-berlin.de>
+for ktouch from a training file distributed by
+Andreas Kalbitz  &lt;felix@pingos.schulnetz.org>
+for Tipptrainer V0.4 http://www.pingos.schulnetz.org/tipptrainer
+distributed under the GPL2
+Version: 0.1 beta  (Modified for Swiss keyboard layout)</description>
+ <keyboardLayout>ch</keyboardLayout>
+ <lessons>
+  <lesson>
+   <id>{538f576c-135e-46b2-86f2-333488359bdd}</id>
+   <title>Grundhaltung 1</title>
+   <newCharacters>dfjk</newCharacters>
+   <text>ff jj ff jj ff jj ff jj ff jj ff jj ff jj ff jj ff jj ff jj
+fj jf fj jf fj jf fj fj jf fj jf jf fj jf fj jf jf jf jf fj
+ffj ffj ffj ffj ffj ffj ffj ffj ffj ffj ffj ffj ffj ffj ffj
+jjf jjf jjf jjf jjf jjf jjf jjf jjf jjf jjf jjf jjf jjf jjf
+jfj jfj fjf jfj fjf jfj fjf jfj fjf fjf fjf fjf fjf fjf fjf
+fff jjj fff jjj fff jjj fff jjj fff jjj fff jjj fff jjj fff
+fjf jfj jfj jfj fjf fjf jfj fjf jfj fjf jfj jfj jfj fjf fjf
+dd kk dd kk dd kk dd kk dd kk dd kk dd kk dd kk dd kk dd kk
+dk dk dk kd kd kd kd dk dk dk dk kd kd kd kd dk dk kd kd dk
+ddd kkk ddd kkk ddd kkk ddd kkk ddd kkk ddd kkk ddd kkk ddd
+ddk ddk kkd ddk kkd ddk ddk kkd kkd ddk ddk ddk ddk kkd kkd
+dkd kdk dkd dkd kdk dkd kdk dkd dkd kdk dkd dkd kdk kdk dkd
+dkk kkd dkd dkk kkd dkd kkd dkd kkd dkd kdk kdk dkd kdk dkd
+ddd kkk dkd kdk dkk kdd ddd ddd kkk dkd kdk kdk dkd kkk ddd</text>
+  </lesson>
+  <lesson>
+   <id>{8194dc73-5356-45a8-91cb-faa53004f4f1}</id>
+   <title>Grundhaltung 2</title>
+   <newCharacters>aslö</newCharacters>
+   <text>ss ll ss ll ss ll ss ll ss ll ss ll ss ll ss ll ss ll ss ll
+ls sl ls sl sl ls sl ls sl sl sl sl ls ls sl ls sl ls sl ls
+ssl ssl lss lss lss lss lss lss lss lss lss ssl ssl ssl ssl
+lsl sls lsl lsl ssl sls lsl sls sls lss lsl sls sls lsl sls
+ssl lsl lsl sls lss lls lll sls lsl sls lsl sls sls sls sls
+lsl sls lsl lls lsl ssl sls lls lls lsl lls lsl sls lsl lls
+lll sss lsl lll lsl sss lsl ssl ssl lsl lls lll sss lsl ssl
+aö öa aö aö öa aö öa öa aö aö aö öa öa öa aö aö öa öa aö aö
+öa aa öö aö öö aa öö öö aa öa öa öa öa aö aö öö aa öö aö öa
+aöa öaö aöa aöa öaö aöa aaö aaö aaö ööa aaö öaa öaö ööa aöa
+ööö aaa aöa ööö aöa aaa öaö aöa aöa öaö aöa aöa öaö aöa öaö
+aöa ööö aaa aöa aöa aöa öaö aöa aöa aöa öaö aöa aöa ööö aöa
+aaö aaö aaö öaö aöa ööö aöa ööö ööö ööa ööa aaö öaö aöa ööa
+aöa aaa öaö aöö ööa aöö ööa aaö öaa aöö öaa aöa öaö aaö öaa</text>
+  </lesson>
+  <lesson>
+   <id>{7c5080f2-6117-40da-83a7-30ac1c5ede83}</id>
+   <title>Zwischenübung</title>
+   <newCharacters></newCharacters>
+   <text>asdf jklö asdf jklö asdf jklö ölkj fdsa ölkj fdsa asdf jklö
+asdf ölkj asdf ölkj asdf ölkj asdf ölkj asdf ölkj asdf jklö
+askj asjk askj askj asjk asjk asjk asjk asjk askj askj asjk
+lsöa lsöa lsöa aösl aösl aösl aösl aösl aösl aösl aösl aösl
+alsö aösl lsöa löls löss skök lsöa slöa löal ölsö slaö söal
+aösk alsk aöls aöls aöld aösl aösk asök öska alök asld öskö
+dask klsa klsd dlsa öldk dkls ölsa klsa klas lkas slak skal
+fksk dksl jfjf skdj dsaj jafj jsdj fjdk jfkd fjdk fjdk fjdk
+fkds kldj jkld fdsa fdsa fdsa fdsa jkls sakd dsaö jkdk djfk
+slaö aljs sdkf dkls kkls llsk söak dlsd sldl dlsl dsld dlsl
+dlld ldld sösl alsö dlfk fldk fkld kfal fals lssa lass lass
+lsls ldfj kalf klas lkas jdks lsak kdfj alsj lkdf kjja jaja
+falk lfds fall lfds jfks fall falk fall fals slak dlsa lsdf
+jkak kaks lkak ksda kdls lsdf dsaj kjlj lökd fksl slkd jkls
+ffkd kdkk dkks saak sask ssas dsas klöl dsas lkkl lkjk lkjl
+aösl ssas llkö kkök ölkj lkjl ölkö ölöa ölks öklj jlkk lkds</text>
+  </lesson>
+  <lesson>
+   <id>{574a6b59-ea61-492e-99fd-de5ac4e71ad9}</id>
+   <title>Zwischenübung</title>
+   <newCharacters></newCharacters>
+   <text>sla las laa aal sla lsa las sas lsa laa las all als ass als
+all als las all als las all als las all als las all als las
+sla sal sla sla saa sas asa lal ala als sss lsa sla sll sla
+las als all las als all las als las als all als all las als
+sls lsl lal sas lls ala lal las asl las sal las als all sla
+als all las als all las als all las all all als als las las
+fad das sad lös las lad lad aal fas kal sal fas dsa dks fda
+fall lass kalk lass klas salö salk laös llsa llsa ölsa lsaö
+ösal löss ösks öskl öslk lsal löas klsa löls löls klsa klös
+kalk kalk fall fall falk lass lssa lass kalk falk fass sass
+safd safd klöa aölk lsal lsas slas lsls fjdl alsa jaja jdld
+jldd kjsk klas kalk saal lass fakl sall lall ladd ladd dsal
+falk kalk falk kalk saal kalk falk saal kalk fall saal fall
+falk fall fals kall kalk saal falk lass kalk löss lass fall
+falk kalk fall löss kalk fall saal fall löss saal fall falk
+lass fall lass falk kalk saal fall löss kalk kalk saal fall
+falls kafka kajak kajak falls falls kafka kajak kajaj kafka
+kafka falls kajak falls kafka falls kajak kafka falls kajak
+falls als falk kalk kafka das all das lass das las als kalk
+öl als löss kafka kajak öl als all falk löss lass las kajak
+all das öd all dass das öl kafka lass das ja kalk öl ja las
+all das saal falk kalk kajak kafka saal falls das dass lass
+als all das öl falls all das öl ja als all das öl kafka las
+falls falk all das las das öl als all kalk fall saal las ja
+ja ja sass da als all das öl kafka las falk sass da als all
+das öl lass das all kafka las all falls all das öl as ja da
+da das alls kafka las kalk fall saal falls all das öl ja ja</text>
+  </lesson>
+  <lesson>
+   <id>{30b3f653-2953-45f6-b2c5-c3c4ba2ff6cb}</id>
+   <title>i und e</title>
+   <newCharacters>ei</newCharacters>
+   <text>de ki de ki de ki de ki de ki de ki di ke di ke di ke di ke
+dak dik dak dek dak dik kid kid dik eki ede kde dek dei die
+sei sie lie ise asi esi ase las lie fie kis eis ise ike eki
+jie jei eij eej jee jii sii ees iis ais iis ssi sse sie ies
+kei iek kii kee eke ike adi ida ede ese see ise isa sai sae
+lee lei lie lle ill eel sea eas ase lea kea jea sik aik eik
+kade lade jade lade kiss lies like daks jade jedi kadi sadi
+kess lass löss lies siel alle fell fiel fail siel fiel feil
+seil lies keil like feil fiel jail dail das is fis ais lief
+fiel fall feil dies seil jade keks siek jedi fade sade lade
+file seil siel fiel jail lade like jedi kadi eile alle eile
+siele lalle falle kalle seile feile leise keile lalle falle
+alles kalles elle felle fiele öse seile keile fiele die eis
+lasse fasse kasse sasse löse sie lasse fasse kasse asse die
+isa kies alias salsa else fels als je ja sass iss kiss esse
+lasse kasse kaffee affe safe lief ilse kleie eise seile sie
+ade alle lies alias alles falle felle kalle kill keil kille
+elle alle delle seile eile keile kiel fiel siel adidas lies
+ja das alles dies lies sie alle eile leise feile delle asse
+kasse lasse diese dieses dies lies fiese lade sade fade eis
+jail file alias kiss sed deal seal lease fade ill fill feel
+kaffee fiel alles eile kalle feile sie seil seile kasse eis
+ja sei da fallada kafka saal öle öse als alles fiel siel es
+lade es fade saal es das fass es ja fiese liese lies dallas
+das da die sei jede jedes diese sei seife eides filiale eis
+dies des seide dieses fidel lief des alles lies das kleides</text>
+  </lesson>
+  <lesson>
+   <id>{68d858c0-a520-4195-a4d2-e0efe56fde02}</id>
+   <title>g und h</title>
+   <newCharacters>gh</newCharacters>
+   <text>fgf fgf jhj jhj fgf jhj jhj fgf jhj fgf jhj fgf jhj fgf jhj
+fggf jhhj fgjh fgjh fgjh fghj jhgf fghj fgjh fghj gfhj fgjh
+fgf gfg jhj hjh gfh jhg fgj jhg fgh jhg hgf ghf hgf ghf fjh
+fga agf gfa fga fag fga fga afg fag fag fag gaf gfa gag gfa
+jag ajg jag ajg ajg gaj jag jga jga gja fgj gjf ajf agj ajg
+öjh hjö hjö öjh jöh jöh hjö jhö öjh öjh jöh jöh jhö ögö öhö
+afg öhj agh öhg agj öhj gaj höj gaj hög hag ögh öhg ahg öhh
+haag haff haag haff haag haff fahl half fahl half hasl lasa
+kahl lags slag glas alga gala agfa haff haag glas lags gasa
+gesa sage hage jage fehl fahl hege gehe hege gehe sehe hase
+hass fahl kahl kehl kiel geil lieg heil hies dega gade jage
+jagd jögh hals gels gisa löse geis sieg igel lieg lage gala
+egel flegel fahles kahles sage es kegel segel jagd laage he
+hegel flegel kegel fahle ihle ahle alge felge selige heilig
+heilige eilig seele gelee heel heals hall he his heise leis
+geisel feige fehle helfe half fege diggi daggi jiggi jag is
+geige feige liege fliege siege diehle fiele galle falle heg
+hilfe heile half fall gehe giga glas flies dies see eisiges
+die eisige see die alge das fass das glas das glas seidiges
+gaffe haff kaff die alge  die felge siege sage gehe sehe es
+she is his he is she lies es gase gas hass fass lass kahles
+gisela höhle sah diese höhle geöle hase jade jage lage heil
+hadi sage lass das fass dies seidige kleid gehe hege gelege
+geklage gelage sage die sage gejage klage felge helge leide</text>
+  </lesson>
+  <lesson>
+   <id>{cfeb09fa-6f1a-49e4-8559-ac21230531b4}</id>
+   <title>w und o</title>
+   <newCharacters>wo</newCharacters>
+   <text>sws lol sws lol sws lol sws lol was los was los was los was
+was sws los lol sws lol was los wag weg wog log los weh wie
+log los was wow lol sws wow sow saw osw aso oso los kos jas
+kdw dwk jdw wdj okw wok wie aol das los leo loe lei wei wie
+gold geld soll will kilo lose kose wald jagd wage lage lego
+hose hase lode ewig soda dose wild will soll wald feil woll
+weise leise heise hose lose wiese waffel wieso weil was wie
+wiege weise will logo leise wiese wiese wieso wald was wohl
+waage wiege agil wog was wieso wald waldig wilde kilo wieso
+jage wildes wild wald was sah sie wie log sie was wieso log
+isa die wiese lag weg wie weil sie wo sowieso lolö öle ölig
+loewe leise lose gosse gasse hose dose diese woge loge wade
+wash fish who is who was whose fool while whole who goes he
+goes she goes goal she saw dow kill as file off while whole
+false welsh wise whis joda jedi fish flash dog ale while we
+wie weise wieso kafka was las als da was fiel die hose lose
+die gosse sie wog je dose kaffee das was sie sah die kladde
+sie fiel da die wade kafka fade das die lade los es wog was
+kafka las die kladde als was fiel was wog das löss wege weg
+öle die waage das wog kafka las wie las kafka die kladde da
+wieso lass sie wog diese kasse affe wog die waage log sowas
+die wiege die waage das segel flog die woge die jagd so wie
+das wild floh es goss waldig eisig als die wiese wie willig</text>
+  </lesson>
+  <lesson>
+   <id>{3e39987a-5238-4579-92b9-bdd307f57971}</id>
+   <title>r und u</title>
+   <newCharacters>ru</newCharacters>
+   <text>frf frf juj juj juj frf fuj juf uuj uuj fuf uuf ruu uru ufr
+fra aua fau fra fru jau jar dau dar sau sua sar sra öuö rör
+ded kik juj ded frf ase ras juk kuj fuj ruf dei ser usl öre
+war wor rio rus ras ral rel ril rol ole oli koi oki dok rod
+eul eur edu sui seu weu leu keu heu geu feu deu aeu are dar
+frau ursl fahr wahr wehr wors wurs juss juhu uhus guss fuss
+raus haus laus daus wars waru daru karu saru laru jaru ufos
+gard hars kars lars jare jarr jeuh jerr kerr herr gerr gurr
+darauf klaus uwes rufe jeder rief alles rief sehr ruf werke
+darauf  dass klaus das rief wolle rolle solle kuddel suddel
+alles was das haus so liege der wille der frau der herr aus
+rief das alles was die seele jaja ferkel hase wolf uhu eule
+rehe jage wild gewehr erlege kugel wars kugel flog reh floh
+hase lief wolf rief war es der wolf der da so rief der hase
+luise las das auf was fiel so fiel der herr das war wohl so
+wer lief der rief regel gewehr soll der hase wohl war es da
+hallo wer war diese halli hallo hallöle hallali hirse hafer
+rede lies sage wage rufe lusiese sie war es kuss fred gelle
+wars ulli sage es liese war es dieses haus klaus rede ruhig
+ruhe wer da rief das lief so weil das haus ruhig lag es war
+wage es war dusselig es war eisig weil luise da war egal du
+will es kalle oder ole hose aus wolle kleid seidig haus aus
+löss fiel kafka was er rede ruhig lies es ruhig aller regel
+das regal das fiel der saal war leer wars fred wars ole was
+war luise wer ulli wer dario alles lief  als das regal fiel</text>
+  </lesson>
+  <lesson>
+   <id>{26c9b437-3f79-4c84-9772-852aa5e1983f}</id>
+   <title>Zwischenübung</title>
+   <newCharacters></newCharacters>
+   <text>aufs dies jura soda hier ufer haus erde frau juda judo joda
+ruhe rase glas gras fass fuss ewig jahr rede klar aula fuhr
+lauf lief rauf rief dorf darf half hilf hole sole rose lose
+hose ferse hirse kriese kreise leise heise weise aus garaus
+weise welle welse ferse wohlig wasserglas wasserfass wildes
+frage gelage heraus wieso darf fasse wasser lasse oswald wo
+war da was  wieso war der das eilig wohlig ruhig eisig hals
+hilfe kalle saal solle wolle wille wild wilde wildes waldig
+wollo kohle sohle dohle gejohle logo sog flog woge jod hose
+jagd gewehr eule geheule keule kuhle soul klaue wohlig hole
+war er das  war sie das  wer war das wohl  wieso war es so
+weise leise reise heise kriese wiese ferse hirse garaus was
+also was soll das  weil das so sei  klar das war so ja das
+was so war  was soll er was will er wer will es wer soll es
+er soll was sie soll was sah er was so sah es aus was wohl
+sie wolle was so er sah wer will das da wer soll wer ursel
+alles war da was fiel das war gerade gefiel er jodele wolle
+walle walle falle gefiel gefahr gewehr wars wurde gulli
+woge flog sog sauge lauge klaue dau gerade gelage woge woge
+wage sage frage frau herr hausfrau hausherr heraus goldig
+falke eule uhu juhu also falls das so war  war es so klar</text>
+  </lesson>
+  <lesson>
+   <id>{8029cb35-c799-44dc-a820-4d89e245f36d}</id>
+   <title>t und z</title>
+   <newCharacters>tz</newCharacters>
+   <text>ft ft ft ft ft ft jz jz jz jz jz jz ft jz ft jz ft jz ft jz
+ftf jzj ftf jzj ftz jzt ftz jtz fzt jtz ftz fjt fjz fjt fjz
+dzd fzf dzf dzd dzd szs aza ata sts sts ktk tlt ltl ötö özi
+zög zöge zog log lok teig teil tide tage tag zarge zag zuse
+ast last hast fast hatz fatz latz katz katze satz satz jazz
+zu zur zeit ziel zahl ziel zeit teil teile heil feile zeile
+ziele ketzer satz heile zeile ziele teile tief tage lage zu
+dutze kartzer kratze kratzer latz garz jetzt kerze kurz zur
+zeit seit der zeit zeisig ziele zahl zahle dutze kratze tue
+zarge zulu taz fratz jazz katze kurzer kurz letzte lust las
+zog er gefasst lasst trage frage trug zur hetze falz fetter
+herr fette öle zola ritze der herr zog das heraus gezielter
+welt erde orte worte warte zarte witze werte harte karte zu
+der zug zog er flog sie lief es geht halt das  halt auf zoo
+wetter wettere watte lagert wagt es gelegt gelege fegt dies
+löss fiel saugt es auf fegt es auf liest er was  er las das
+wieso liest er das wer sagt etwas gesagt getagt gewagt erze
+löst es auf gelöst geht er wer wagt geht wer zaudert steht
+fast gewagt ist gesagt tag tue eis taut auf zahl das eis da
+kafka liest der titel ist das tier war da weil dies tier da
+war  fiel der krug alles lief  half  saugte sagte rief geht
+also daher wer geht geht jetzt er liest die kladde wer hört
+da zu er hör sie hört kafka liest zola elise fragt fritz da
+der was hörte wartete kafka sagt zu elise geht jetzt frau
+es stört wer da fragt die woge erstarrt alles stille
+elise geht es war kafkas wille sie geht als der krug grade
+fiel der saft lief der autor rief alles eilte dazu jetzt
+war ruh</text>
+  </lesson>
+  <lesson>
+   <id>{72c11609-d70c-4981-a0f0-20382f667e66}</id>
+   <title>Zwischenübung</title>
+   <newCharacters></newCharacters>
+   <text>der die das wer wie was wo der die das wer wie was wo da so
+sehr steil sehr stark her klar sogar das der das die daraus
+dass das dass das es was klar sogar das dies wie es ist sag
+sah sehe sieh daraus woraus des dies dar wer wo was weg war
+der die das des dies diese dieser dar daraus der der dieses
+wer wieso war was wo woraus wort worte wolle wollte soll es
+sollte hole holte hals halt halte falte kalte altere walter
+walte wer will wer soll wer ist wer hat er hatte sie hat du
+du hast du sollst du willst du holst du sagst du sagtest es
+was sagt er da was hat er da was soll das da was will er da
+wer will das wer soll das wer hat das wer sagt das was sagt
+sie sie sagt was er hat er sagt dass du das sagtest was sie
+gesagt hat er sagte dass sie es ja gesagt hat gesagt hat er
+heute dass sie es gesagt hat sie tat wieso sie das tat weil
+sie das tat was er sagte ja er sagte was sie tat es tat weh
+heute hat er heu geharkt das gras war heu heutzutage hat er
+alles was er will jeder hat was er will jeder ist wer wieso
+er das ist was er ist ist klar weil er isst was er ist weil
+es so gut ist dass er es isst wo er es sieht dazu sagte sie
+dass er heute isst was sie will lege die karte auf die erde
+wo geht es zur see wie geht es heute geht es gut es geht so
+so wie das geht geht es gut gut gesagt der fluss das wasser
+löse das seil jetzt ist es so weit auf dieser welt sagt sie
+alles was sie weiss was weiss sie alles wer wusste das</text>
+  </lesson>
+  <lesson>
+   <id>{db1adb3c-a61a-440b-824a-9ebd3d915a35}</id>
+   <title>q und p</title>
+   <newCharacters>qp</newCharacters>
+   <text>qp pq qp pq qp pq qp qp pq qp qp pq pq qp pq qp qp qp pq pq
+qu qu qu qu qu qu qu qu qu qu qu qu qu qu qu qu qu qu qu qu
+pr pr pr pr pr pr pr pr pr pr pr pr pr pr pr pr pr pr pr pr
+op op op op op op op op op op op op op op op op op op op op
+qua quo qua quo qua qua quo que que qua quo que qui qui quo
+pra pra pro pro pro pro pre pri pre pra pro pra pre pri pru
+pod qua pas pes pis pid pad ped pre pfa pfe pfi pfo pal ple
+pli ple pla pek pik pak pok pei peu pou pol puk pfu pfr pfu
+faq fap dap kap lap laq leq geq seq que hap kap sap paw wap
+quer quar quap quir quet quel qual quod quep quer quar quas
+pros pras pris prid prod prad prol pril pral peil pfei pfah
+pfla pflo plat plas plea plig plik plag pleg plus plei plie
+quil quik quas wapp weap wipp lipp dipp sipp hipp kipp ripp
+qual real praktik praktiker pelle pille palle qualle quelle
+prall aufprall spiel gefiel progress proto prater prall pro
+prof prokura prokurist predator presse erpresser protze opa
+oper opera portal portiert apropos quelle portierte plagiat
+plage pflug egge quast quest top hopper plaque platz pfeile
+quoll geplagt gesagt gefragt preis preise leise quassele op
+oper rap rippe rappe ertappt getappt getippt tip wippe pril
+prasse presse klappe klappere geklappert depp stupid steppe
+stop stoppt alle er ist gestoppt sie isst er stopft tropfte
+das wasser tropft der wasserfall gefoppt poppig pope papier
+pappe lappe radikal gerappt gerafft das wasser quillt leise
+heraus aqua aquarell artist produkt palette preise pflaster
+paragraph perl protokoll sparpreis kapitalgruppe post paare
+quadrat quadrate quadratur des kreises philosoph pause quiz
+porto partie partei plato padua parkplatz professor pariser
+reprise die quelle des flusses die weserquelle europapokale</text>
+  </lesson>
+  <lesson>
+   <id>{256e9080-6c95-4d5f-8f22-81e83ae00813}</id>
+   <title>v und m</title>
+   <newCharacters>vm</newCharacters>
+   <text>vm mv vm mv fv jm mj vf fm vj jv mf vf gv jm hm mj mh mg vh
+vi va ve vr vg vi vu vo av ev iv uv ov uv me ma mo mi me mu
+vim vam mer mar mir mei mol mal mie mig mag mog meh muh mau
+vau vei vie vor vol val jav jov jev jam mai maj mer wem vim
+viel vase vers mehr maar mit voll pomm luv rom reim warm am
+vom wem dem ihm rum mull male maus mais mies muss kaum moos
+viel oval volk vater immer mehr immer mehr meister viele im
+vieles muss meise mehr mus meer viele klammer wieviel warum
+mitte mittel matte matt platt platte watte quaddel mast mus
+vertrag kaum verzug vermerk zuvor zuviel jemals vorteil ihm
+vorgemerkt vorgesagt vor dem saal im stall muster kohlmeise
+makulatur mogelei malerei verse ferse merke markiert markus
+mimik hervor herum vertreter wurde mehrere verkauf verglast
+fremde vögel vogel des vogels vögel klaus kommt aus amerika
+es stimmt die stimme der stummel verlade gestammelt stummer
+kummer fummel hummel summe summt krumm kram er kramt lahmer
+verkehr verkehrt herum umfahre marktplatz wer mag apfelmus
+lava magma mutter vater gemerkt vermerkt vermarktet versagt
+vermisst vermiest verklagt verzagt er verzog werktags werft
+er vertrat klaus vertrat fred vera vertritt maria uta reimt
+verse paul liest verse vom autor kafka goethes verse las er
+am mittag wer liest zolas werke daheim liest sie heim jedem
+etwas mit viel gehalt die werte qualle im meer klammtal die
+quasselstrippe warum streift der kater herum es ist so kalt
+die katze sitzt im haus herum sie miaut zu laut verwahre es</text>
+  </lesson>
+  <lesson>
+   <id>{77936aa4-ec36-4208-9cff-309273975b00}</id>
+   <title>n und b</title>
+   <newCharacters>nb</newCharacters>
+   <text>bn nb bn nb nb bn bn nb nb bn nb bn gn gn gb hb bh jb fn bf
+gn fn gb bg fb hb bh jb bj kb bk db bd sb bs ab ba lb bl bö
+öb bo bu bi no nu ni ne be br bw kb bk bt tb zb bz ln nl vn
+jnj jnj njn fbf bfb fbf bfb jnj njn bfj njf gbt bgt nju njh
+hun han kan fan bus und ohn pon ihn ein nie nun neu nah den
+din win pin uin ein nau bau bew beo boh bog bag big gib gab
+geb fab dab sab kab lab lan dan san wan han zen ren wen tun
+nein wein kein bein bier kein tier aber ober bald bild blei
+blau blue baff biff bahn sein wein wohn wien sinn fein kein
+neid pein rein eine leim fein huhn hahn nuss bann kann wann
+dann mann nein bett bass biss boss blau wald bald halt salz
+beginn gewinn allein negation blamage bagage tonnage gebete
+gebeten sagen fragen plagen nagen neige trinken singen sang
+klang fang den ball alle singen den song alles nur sinnlose
+singerei er hat viel zu tun die tante kommt zu ihm umziehen
+der umzug kostet viel geld seine einnahmen waren angemessen
+zu lies das manual sagt man rtm die informationen findet er
+dort zuerst wer liest lernt er sie liest viel uta lernt was
+man tun muss um arbeiten zu können könnte sein dass er nein
+sagt aber fragen ist besser als warten wen interessiert das
+alles was man lesen kann hilft beim lernen fahrt ski in den
+bergen beine festhalten er will reinen wein wann wird er es
+lesen kafka soll seine verse lesen alle wollen ihn hören da
+er so eine tiefe stimme hat eva strittmatter liest viel aus
+erbe ihres mannes aber die eigenen verse sind ebenso gut zu
+lesen  ist heine vergessen  keine ahnung  ist heine bekannt</text>
+  </lesson>
+  <lesson>
+   <id>{a2ad917d-fe44-4186-b68e-080d9096742e}</id>
+   <title>c und ,</title>
+   <newCharacters>c,</newCharacters>
+   <text>c, c, ,c dc cd k, ,k k, ,k cd dc ck kc d, ,d ck k, c, d, k,
+, , , , , , , , , , , , , , , , , , , , , , , , , , , , , ,
+ck ck ck ck ck ck ck ck ck ck ck ck ck ck ck ck ck ck ck ck
+cd, cd, cd, cd, cd, cd, cd, cd, cd, cd, cd, cd, cd, cd, cd,
+dcd k,k dcd k,k dcd k,k dcd k,k dcd k,k dcd k,k dcd k,k dcd
+sch sch sch sch sch sch sch sch sch sch sch sch sch sch sch
+sch, sch, sch, ch, ch, ch, ch, ch, ch, ch, ch, ch, ch, sch,
+ddcc dcdc dccd cddc dcdc cddc dccd cddc cdcd ddcc ddcc dccd
+k,,k k,k, ,,kk k,k, kk,, k,k, k,k, ,k, k k,k, k,k, ,k,k ,kk
+ac ac ca ca acdc dcca ac acdc acdc ak,k ak,k ak,k k,ak k,,k
+fc cf fccf fccf fcf fcf cfc fcf fcf fccf cffc cffc cfcf cfc
+lcl lcl clc llcc clc clc lcl lcl cllc lach lach wache mache
+ach auch doch dach ich mich sich nicht euch ich welch solch
+solche molche welche jene, welche der, die, auch, wenn nun,
+da sobald, wenn, dann gerade, als je mehr, desto besser, so
+wie du,  na dann,  ich bin, glaube ich  wer glaubt, der ist
+dick lack leck auch dich doch deck lech dach loch doch noch
+buch fluch such versuch betrug falsch pflicht verzicht auch
+versuchung besuch tuch tauche seuche verflucht gedichte chi
+eva liest gedichte die ich schon lange kenne, doch schön
+sind sie doch  auch, wenn der saal nicht voll ist, wird er
+seine verse lesen kommt das komma da hin, oder da hin  ich
+will gerne kommes setzen, doch ich mache das sicher immer
+falsch  na schön, wenn es sein muss, dann auch mit kommata
+schick, schlank, schnick, schnack, schön, schade, schwer,
+schlank, schön, schöner, schneller, zu schnell, schriftlich
+hilfreich ist, wenn man die regeln zur kommasetzung kennt
+auch wenn der rechner streikt, musst du die ruhe bewahren</text>
+  </lesson>
+  <lesson>
+   <id>{3999e8df-dc1c-4898-9718-b6f4550dbe6e}</id>
+   <title>x und .</title>
+   <newCharacters>x.</newCharacters>
+   <text>x. x. x. x. x. x. x. x. x. x. x. x. x. x. x. x. x. x. x. x.
+x.x x.x x.x x.x x.x x.x x.x x.x x.x x.x x.x x.x x.x x.x x.x
+xx.. xx.. xx.. xx.. xx.. xx.. x.. xx.. xx.. xx.. xx.. xx..
+axa ö.ö axa ö.ö axa ö.ö axa ö.ö axa ö.ö axa ö.ö axa ö.ö axa
+axt exe axt exe ol. ol. mol. mal. mel. en. en. en. ein. en.
+fax max axt axt. fax. max. a..a s..s d..d f..f j..j k..k xx
+exe exa ex dax sax fax nux lux mux  tux exakt lexikon lexik
+tux. taxi text textur taxen taxator taxameter saxophon lexx
+tux. tex. exakt. explosion. exorbitant. mexiko. exempel. ex
+tux luxemburg. fix. fax. fixum. fixieren. extrakt. extra.
+tux nixe verflixt fixen ein problem fixen. fix. max. lol l.
+tux. den text revidieren. xerxes, der perserkönig war nicht
+in luxemburg, sagt er. felix lebt nicht am existenzminimum.
+linux linux linux linux linux linux linux linux linux linux
+tux tux tux tux tux tux tux tux tux tux tux tux tux tux tux
+taxi fahren ist toll. linus begann mit linux als student.
+auch heute arbeiten viele studenten an der entwicklung von
+software, die unter linux laufen soll. exakt nach dem start
+blieb der wagen stehen. der fahrer schloss erstmal alle
+fenster. er war programmierer, doch er kannte linux nicht.
+nach der explosion war der saal leer. kafka las erstmal die
+verse nicht mehr weiter, bis sich die aufregung legte. text
+der text aus dem lexikon ist nicht ausreichend. deshalb las
+sie auch noch die entsprechenden seiten im internet. ende.</text>
+  </lesson>
+  <lesson>
+   <id>{bb83a31a-2456-4491-8b0d-6a3195f06daf}</id>
+   <title>y und -</title>
+   <newCharacters>y-</newCharacters>
+   <text>y- y- y- y- y- y- y- y- y- y- y- y- y- y- y- y- y- y- y- y-
+y- y- y- y- y- y- y- -y -y -y -y -y -y -y -y -y -y -y -y -y
+ö-ö ö-ö ö-ö ö-ö -ö- ö-ö -ö- ö-ö -ö- ö-ö -ö- ö-ö -ö- ö-ö -ö-
+aya yay aya yay aya aya yay yay aya yay yay aya yay yay aya
+fsdaya jklö-ö fsdaya jklö-ö fsdaya jklö-ö fsadya jkl-ö-ö a-
+sys l-l sys l-l sys l-l sys l-l sys l-l sys l-l sys l-l sys
+dyn k-m dyn k-n dyn k-n syd ky- syf k-d syg k-h syn jn- hay
+asyl asyl sylt sylt type type asyl sylt sys- teme syn- oden
+bay- ern ana- lyse hygiene dynamo gymnastik lyzeum ly- zeum
+bayern analyse hy- giene dy- namo gym- nastik synode system
+yeti - yak - synthetisches - synergetisch - sylt asyl typen
+yast - yet another setup tool
+sympathisch sympathie hypothek lyon
+als der pc noch nicht das standard-schreibmittel war, und
+förmliche texte in die schreibmaschiene gehackt wurden,
+stellte man mittels bindestrich sicher, dass der rechte
+rand relativ einheitlich wurde. die wörter wurden nach sil-
+ben getrennt. der bindestrich kann aber auch zwischen zwei
+hauptwörtern stehen, um diese zu verbinden, wie in
+kaffee-ersatz. wer sich mit sport auskennt, orientiert sich
+an den punktetabellen, wenn er die ergebnisse verschiedener
+mannschaften vergleichen will. dort wird der bindestrich
+verwendet, um zu zeigen, wer gegen wen spielt.
+    herta bsc - fortuna köln
+in verbindungen wie gertrud-meier-platz oder
+nord-ostsee-kanal wird der mittelstrich ohne leerzeichen
+verwendet. als gedankestrich taucht er auf, wenn man ein
+paar stichworte logisch voneinander absetzen möchte.</text>
+  </lesson>
+  <lesson>
+   <id>{d357879e-b9c9-4f34-b556-248a4a413c2c}</id>
+   <title>ü und ä</title>
+   <newCharacters>üä</newCharacters>
+   <text>öüö öüö öüö öüö öüö öüö öüö üöü üöü üöü üöü öüö üöü öüö üöü
+öäö öäö äöä äöä äöä öäö öäö öäö äöä öäö öäö öäö öäö äöä äöä
+äüä äüä äüä äüö äüä üäü üäü öüö öäü üäü üäü öäü öäü üöä äüö
+öüä öüä öüä öäü öäü üäö äüö öäü öüä äöü üöä äüö öäü öäü üöä
+möhre mähre fähre führe würde könnte müsste hätte täte gäbe
+wäre sähe läge säge wäge mägen lägen lügen rügen trügen übt
+geübt gepflügt - übt bemüht, berühmt, gerühmt, gesühnt über
+flögen die vögel über die meere
+und sähen die mähre,
+gefolgt von dem bären,
+dann würden sie stürzen hinab auf den bösen,
+zum töten bereiten, verfressenen räuber,
+ihn zausen und hacken,
+mit schnäbeln zwacken,
+ihn stechen und jagen
+bis er zög von dannen
+mit hungrigem magen...
+gesöff, krüge, züge, betrügen, gähnen, erwähnen, gröhlen,
+gesänge, gelänge, begänne, zöliakie, zünglein, zündhölzer,
+gezündet, verzückt, glücklich, verrückt, bedrückt, rücken,
+genügend, berühren, verführen, verfahren, für wen, wofür,
+dafür, die tür, das gebälk, etwas gebäck, äpfel, überlegen
+übermütig, gäbelchen, geflügel, gebügelt, verbrüht, bäume,
+verprügelt, die äste, das geäst, die jäger, flöhe fliehen,
+konfitüre, marmelade, breitmaulfrösche ängstigen sich vor
+störchen, die lärche, die lerche, schübe, zöge, träge, er-
+träglich, nachgeäfft, geschäft, kräftig, beschäftigt, über
+von früh bis spät, qualitätsartikel zur verfügung stellen.
+die fläche der europäischen gemeinschaft beträgt...
+vorwärts und rückwärts gelesen ergäbe der text dieser lek-
+tion keinen sinn.
+...ach so, vögel ärgern keine bären.</text>
+  </lesson>
+  <lesson>
+   <id>{77bbbd9e-9945-4b36-8b3f-e50a741a0e24}</id>
+   <title>Capslock</title>
+   <newCharacters>ASDFJKLEIGHWORUTZQPVMNBC;X:Y_</newCharacters>
+   <text>ALLES WAS HIER STEHT IST, MIT FESTGESTELLTER UMSCHALTTASTE
+LINKS GESCHRIEBEN. DABEI BLEIBEN AUCH PUNKT UND KOMMA, SO-
+WIE BINDESTRICHE ERHALTEN. IM FOLGENDEN BENUTZEN WIR DIESE
+TASTE NICHT MEHR, DA DAMIT NICHT DER UEBLICHE SCHREIBALLTAG
+BEWAELTIGT WIRD. DIE BEIDEN ANDEREN UMSCHALTTASTEN WERDEN
+JEWEILS VON DEM KLEINEN FINGER DER HAND BENUTZT, DIE EINEN
+KUERZEREN WEG HAT. DAS IST IN DER REGEL DIE HAND, DIE FUER
+DEN FOLGENDEN BUCHSTABEN NICHT BENOETIGT WIRD. DAMIT IST ES
+DANN AUCH MOEGLICH, ALLE ZEICHEN DER ZWEITBELEGUNG ZU TIP-
+PEN, ALSO AUCH DAS FRAGEZEICHEN.
+DIE ERSTE UEBUNG WIRD FUER DIE UMSCHALTTASTE LINKS, DIE ZWEI-
+TE FUER DIE UMSCHALTTASTE RECHTS SEIN. DANACH WIRD GEMISCHT.
+ACHTUNG, DIE FESTSTELLTASTE MUSS NUN NOCH EINMAL BETAETIGT
+WERDEN. jetzt sollte das capslock-lämpchen aus sein.</text>
+  </lesson>
+  <lesson>
+   <id>{11b17b71-708a-4439-8471-4865c0bc7640}</id>
+   <title>Grossbuchstaben (links)</title>
+   <newCharacters></newCharacters>
+   <text>Ja Ja Ja Ja Ja Ja Ja Ja Ka Ka Ka Ka Ka Ka Ka Ka La La La La
+Ma Ma Ma Ma Ma Ma Za Za Za Za Ha Ja Ja Ha Ha Za Ha Ha Ha Ha</text>
+  </lesson>
+  <lesson>
+   <id>{e0352f14-83af-4c0a-98a5-6806fdf05d78}</id>
+   <title>Grossbuchstaben (rechts)</title>
+   <newCharacters></newCharacters>
+   <text>Fö Fö Fö Fö Fö Fö Fö Fö Fö Fö Gö Gö Gö Gö Gö Bö Bö Bö Bö Bö
+Wö Wö Wö Wö Rä Rä Rä Rö Rö Gä Gä Fä Dä Sä Vä Vä Vö Sö Dä Dä</text>
+  </lesson>
+  <lesson>
+   <id>{d3aa1c68-3af6-432d-93ed-262cfc611394}</id>
+   <title>Grossbuchstaben</title>
+   <newCharacters></newCharacters>
+   <text>Kalk Kalk Wald Wald Rand Sand Hand Land Verstand Klang Tank
+Wort, Ort, Hort, Gehrung, Nahrung, Klarheit, Vergangenheit,
+Art, Hahn, Mahnung, Lohn, Sohn, Hohn, Keim, Krönung, Krone,
+Leine, Leim, Heim, Geheimnis, Verbannung, Bekanntmachungen,
+Training, die Träne, der Trost, trostlos, das Los, Losungen
+Die folgenden vier Lektionen werden aus ganz normalen Text-
+übungen bestehen, danach geht es mit den Sonder- und Zahl-
+zeichen weiter.</text>
+  </lesson>
+  <lesson>
+   <id>{68e54c24-91f9-4b7b-b5d1-40376cc55898}</id>
+   <title>Zwischenübung</title>
+   <newCharacters></newCharacters>
+   <text>Linux - meine Freude
+Es war ein ganz normaler Tag. Alles war wie immer. Ich kam
+aus der Schule und setzte mich an den PC. Homepage verwal-
+ten, Schülerdaten aktualisieren, Unterricht vorbereiten,
+nebenbei ein paar MIDI-Files bearbeiten und E-Mail lesen.
+Mein Windows-PC ist eben gut ausgestattet. Doch dann ging
+es wieder los. Das Abholen der E-Mail dauerte satte drei
+Minuten. Als ich dann im Postfach sah, dass da genau eine
+nicht einmal sehr lange Mail reingekommen war, stand für
+mich der Umstieg fest. Linux musste her. Ich wusste nicht,
+was da auf mich zukommen würde, doch das war mir egal. Es
+konnte nur noch besser werden. Kostenlose Software, gute
+Internetanbindung, arbeiten auf verschiedenen Konsolen,
+es klang vielversprechend. Dann ging es los. Erwartungs-
+voll packte ich mein SuSE-Paket aus und begann sofort mit
+der Installation. Innerhalb eines Tages hatte ich alles
+wichtige, also auch die ISDN-Konfiguration, fertig.
+Einiges an meiner Hardware war problematisch, z.B. bekam
+ich die Soundkarte nicht gleich voll einsatzfähig, aber da
+ich nun sowieso erstmal mehrere Gigabyte an Software zu
+erkunden hatte, störte mich das weniger.
+Eine vernünftige Mailkonfiguration habe ich erst Wochen
+später eingerichtet, doch für den Anfang tat es Netscape.
+Inzwischen arbeite ich seit zehn Monaten mit Linux, und ich
+habe keinen Tag davon bereut. Ich habe wieder angefangen,
+Bücher zu lesen, und meine Fähigkeit, mich auf ein Problem
+zu konzentrieren, statt einfach drauf los zu arbeiten, ist
+irgendwie auch besser geworden. Dennoch gibt es noch sehr
+viel zu lernen.</text>
+  </lesson>
+  <lesson>
+   <id>{abe1fad2-1209-4c46-8ef4-5e0dcfa1f7ab}</id>
+   <title>Zwischenübung</title>
+   <newCharacters></newCharacters>
+   <text>Das Internet
+
+Das Internet ist in aller Munde. Alle wollen daran teil-
+haben, viele wollen daran verdienen. Selbst Boris ist, wie
+jeder weiss, inzwischen drin. Wie aber alles ganz genau be-
+gann, wissen die wenigsten.
+In den späten sechziger Jahren begann die Advanced Research
+Projects Agency des amerikanischen Verteidigungsministeri-
+ums, kurz ARPA genannt, mit der Finanzierung eines experi-
+mentellen Wide Area Network, kurz WAN, um damit wichtige
+Forschungsorganisationen in den Vereinigten Staaten von Ame-
+rika zu verbinden. Dieses Computernetz wurde ARPAnet ge-
+nannt. Das ursprüngliche Ziel bestand in der Freigabe teue-
+rer und knapper Rechnerressourcen an Auftragnehmern der Re-
+gierung. Von Anfang an wurde das Netzwerk von den Benutzern
+aber auch für die Zusammenarbeit, also der gemeinsamen Nut-
+zung von Dateien und Software, dem Austausch von E-Mail und
+der gemeinsamen Entwicklung und Forschung über gemeinsam ge-
+nutzte entfernte Computer, verwendet.
+In den frühen achtziger Jahren wurde über eine Protokoll-
+Suite nachgedacht. Es entstand das Transmission Control Pro-
+tocol, Internet Protocol. Dieses wurde im ARPAnet schnell
+Standard. Mit der Aufnahme dieses Protokolls in das populäre
+BSD Unix-Betriebssystem der University of California at
+Berkeley begann die Demokratisierung von Netzwerken. Es wur-
+den zunächst Universitäten verbunden, doch es dauerte nicht
+lange, bis die in ein lokales Netzwerk eingebundenen Compu-
+ter über das ARPAnet kommunizieren konnten. Das Netzwerk
+wuchs und wuchs. Waren es anfangs noch eine Handvoll Hosts,
+so wurde es schnell ein Netz von Zehntausenden von Hosts.
+Das ursprüngliche ARPAnet wurde zum Rückgrat des Internet.</text>
+  </lesson>
+  <lesson>
+   <id>{5624e3c0-2e09-4e38-b514-60a88777046e}</id>
+   <title>Zwischenübung</title>
+   <newCharacters></newCharacters>
+   <text>A. Kalbitz
+Lesung
+
+Samstagabend, Feierabend. Beine hochlegen, abschlaffen,
+das miese Fernsehprogramm über sich ergehen lassen, schla-
+fen. Ein Leben lang berieselt von den Impressionen irgend-
+welcher Fernsehredakteure, Krankenhausserien - Ein Muss,
+zumindest, seit Dr. Brinkmann in der Schwarzwaldklinik zu
+Weltruhm vor der Aerzteschaft der Fernsehwelt gelangte.
+Aber da war doch noch was. Da gab es noch andere Möglich-
+keiten der Freizeitgestaltung. Beruhigt lehne ich mich zu-
+rück und merke kaum, wie mir die Augen zu fielen.
+Es ist höchste Zeit. Gleich beginnt die Lesung, und unser-
+eins sitzt noch im Taxi und sucht die Eintrittskarten.
+Ich bin absolut kein Kafka-Freund, aber es ist mal was an-
+deres.
+Endlich - wir betreten den Saal und erwischen schnell noch
+einen Platz in der letzten Reihe. Es wird dunkel. Nur vorn
+auf der Bühne strahlt ein greller Scheinwerfer auf das et-
+was zu kleine Lesepult. Applaus. Von der Seite tritt ein
+Mann herein, den ich nicht kenne, der aber als Autor vor-
+gestellt wird, und der sein neuestes Werk auszugweise vor-
+lesen soll. Er setzt sich, räuspert sich noch einmal und
+blättert bedächtig in seinem Buch. Bei einem Lesezeichen
+hält er inne, überfliegt die Seite, wirft noch einen Blick
+in den Saal, als wolle er sagen - Achtung, es geht gleich
+los - und atmet tief ein, um zu lesen, als plötzlich ein
+lautes Krachen den Saal erfüllt. Das war kein Schuss,
+dachte ich gleich. Derartige Geräusche kennt man ja aus
+den Actionfilmen im Fernsehen. Der Stuhl eines Gastes kann
+auch nicht zusammengebrochen sein. Dafür war das Geräusch
+zu laut...</text>
+  </lesson>
+  <lesson>
+   <id>{ffc77c76-9443-4d35-a618-6da92146e42a}</id>
+   <title>Zwischenübung</title>
+   <newCharacters></newCharacters>
+   <text>A. Kalbitz
+Was hat...
+
+Was hat uns so verblendet,
+dass alles was wir schaffen,
+gemessen wird an anderem,
+verglichen wird, getaxt, bewertet
+und am Ende nicht verwendet.
+Was hat uns nur so abgestumpft,
+dass wir nicht erstmal sehen,
+warum da einer etwas tut,
+ob er es schafft, noch Hilfe braucht,
+am Ende wirds gemeinsam gehen.
+Was hat die Menschen kalt gemacht,
+dass mancher gleich darüber lacht,
+wenn einem mal ein Missgeschick
+die Röte auf die Wangen malt, er sich blamiert,
+verletzt dann einfach resigniert.
+Was hat verdammt noch mal
+der Autor sich dabei gedacht,
+uns unser Dasein zu vermiesen,
+mit dummen Texten, Meinungen und ungeschickt
+gebastelten Gedichten, wie diesem.</text>
+  </lesson>
+  <lesson>
+   <id>{51ae34a8-bc0b-4258-ae38-67af011e123e}</id>
+   <title>&lt; und ></title>
+   <newCharacters>&lt;></newCharacters>
+   <text>&lt;>&lt;>&lt;>&lt;>&lt;>&lt;>&lt;>&lt;>&lt;>&lt;>&lt;>&lt;>&lt;>&lt;>&lt;>&lt;>&lt;>&lt;>&lt;>&lt;>&lt;>&lt;>&lt;>&lt;>&lt;>&lt;>&lt;>&lt;>&lt;>
+&lt; > &lt; > &lt; > &lt; > &lt; > &lt; > &lt; >  &lt; > &lt; > &lt; > &lt; > &lt; > &lt; > &lt; >
+>&lt; >&lt; >&lt; >&lt; >&lt; >&lt; >&lt; >&lt; >&lt; >&lt; >&lt; >&lt; >&lt; >&lt; >&lt; >&lt; >&lt; >&lt; >&lt;
+&lt;&lt; >> &lt;&lt; >> &lt;&lt; >> &lt;&lt; >> &lt;&lt; >> &lt;&lt; >> &lt;&lt; >> &lt;&lt; >> &lt;&lt; >> &lt;&lt;
+Die Zeichen &lt; und > werden als Operatoren benutzt.
+&lt; ist der Eingabeoperator und > ist der Ausgabeoperator.
+Mit ls > dateiname kann ich unter Linux eine Dateiliste
+mit allen Dateien des aktuellen Verzeichnisses anlegen.
+Will ich eine Datei nicht überschreiben sondern Daten
+anhängen, benutze ich >> als Operator.
+In HTML-Quellen spielen die Zeichen &lt; und > eine wesent-
+liche Rolle. Alle Tags, gesprochen: Tägs, werden zwischen
+&lt; und > eingeschlossen.
+Beispiele: &lt;html> &lt;head> &lt;body> &lt;a href... &lt;img src...
+&lt;table> &lt;hr> &lt;br> &lt;p> &lt;li> &lt;ol> &lt;ul>
+Auch in der XML-Syntax werden diese Zeichen verwendet um
+die Tags von den normalen Texten abzugrenzen.
+Häufig werden die Zeichen auch verwendet, um Unterschiede
+darzustellen. Daher stammen auch die Bezeichnungen:
+ist grösser als - für > und ist kleiner als - für &lt;.
+In ASCII-ART-Manier lassen die Zeichen sich ebenfalls gut
+verwenden. Beispiele dazu wird es in einer der Abschluss-
+lektionen geben.
+&lt;->&lt;-&lt;>->&lt;&lt;-->>-&lt;&lt;-->>-&lt;&lt;-->>-&lt;&lt;->>-&lt;&lt;--->>-->>-&lt;&lt;->>-&lt;&lt;>></text>
+  </lesson>
+  <lesson>
+   <id>{3da5a63b-f5f6-40c0-a5b4-a99ce1cb73d8}</id>
+   <title>1,!, ; und ?</title>
+   <newCharacters>1!;?</newCharacters>
+   <text>1! ? 1! ? 1! ? 1!? ?1? !1?! 1!? ??!!11 !!1??!!1
+.!? sind Interpunktionszeichen, die im Deutschen dazu ver-
+wendet werden, um zu signalisieren, dass es sich bei einem
+Satz um eine normale Aussage, einen Ausruf oder eine Frage
+handelt. Wer war das? Wieso machst Du das? Wo kommst Du
+denn her? Das alles sind typische Fragen, bei denen der
+Leser sofort weiss, wie er sie betonen muss.
+Komm her! Sei leise! Hallo! Achtung! Das wiederum sind, so
+sagt das Interpunktionszeichen, Ausrufesätze. Sie werden
+vom Leser ebenfalls deutlich anders gesprochen, als Frage-
+sätze oder normale Sätze, die mit dem Punkt abgeschlossen
+werden.
+Auf der Tastatur werden !?.&lt;> als Sonderzeichen betrachtet,
+was eigentlich nur bedeuten soll, dass sie von den normalen
+Buchstaben unterschieden werden müssen. Ebenfalls unter-
+schieden werden die Zahlzeichen, wie z.B. die 1. Aus Zahl-
+zeichen werden Zahlen gebildet:
+1 steht für eins, 11 für elf, 111 für einhundertundelf.
+Verwendet man das Wort ein in Texten, wird es für gewöhn-
+lich als unbestimmter Artikel verwendet. Das lässt sich
+aber manchmal auch anders interpretieren: Werden kleine
+Mengen in Texten verwendet, schreibt man dafür häufig die
+Zahlwörter ein, zwei oder drei. In Aufzählungen oder bei
+der Festlegung von Reihenfolgen hingegen benutzt man gern
+die Zahlzeichen: 1.; 1. Platz; 1. Durchlauf; 1. Datensatz.
+In HTML wird das Ausrufezeichen übrigens verwendet, um
+Kommentare in die Quellen einzufügen, die dann später in
+der Internetseite nicht zu sehen sind.
+&lt;!-- Dies ist ein Kommentar in einem HTML-Quelltext -->
+Willst Du noch mehr über die Bedeutung von ! und ? wissen?</text>
+  </lesson>
+  <lesson>
+   <id>{bdc9d888-3bf5-4785-ad07-6fb6225c169c}</id>
+   <title>5, %, 8 und (</title>
+   <newCharacters>5%8(</newCharacters>
+   <text>((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
+58% liest man als achtundfünfzig Prozent. Prozent bedeutet
+von Hundert.
+Berechne:
+58% von 1111 EUR.
+88% von 888 kg Mehl.
+%-Werte werden benötigt, um den Anteil an einem bestimmten
+Grundwert zu berechnen.
+In Perl wird das %-Zeichen benutzt, um einen Hash festzu-
+legen. %namen wird dann eine z.B. zweispaltige Liste mit
+Vor- und Nachnamen zugeordnet, die dann in dem Programm
+ausgelesen werden kann.
+In der Bash ist % ein Operator für Modulus-Operationen.
+Das entspricht dem Rest bei einer ganzzahligen Division.
+((((((((((((((((((((((((((((((((((((((((((((((((((((((((((</text>
+  </lesson>
+  <lesson>
+   <id>{03df6991-bef7-4bf8-96b2-98dac8522158}</id>
+   <title>2, 6, &amp;, 7 und /</title>
+   <newCharacters>26 &amp; 7 /</newCharacters>
+   <text>1 5 8 6 7 7 6 5 8 1 67 76 58 85 158 178 167 187 585 151 58
+6 7 &amp; / 16/8 7/5 1/7 6/8 5/8 6/5 8/8 5/5 7/7 6/7 1/7 1/6 &amp;
+Internet &amp; Co.; Max Meier &amp; Söhne; Grunewald &amp; Co. KG
+Das Kaufmanns-und &amp; begegnet uns bewusst oder unbewusst recht
+häufig. Aber es wird nicht nur in Firmenbezeichnungen ver-
+wendet.
+In der Bash dient das Kaufmanns-und als Operator.
+Ein &amp; bedeutet bitweises UND und
+ein &amp;&amp; bedeutet logisches UND.
+In 1>&amp;2 wird die Standardausgabe eines Befehls auf die
+Standardfehlerausgabe umgeleitet.
+Der Slash / wird häufig als Zeichen für die Division ver-
+wendet. Unter LINUX ist es ein wesentliches Zeichen für
+die Organisation der Verzeichnisstruktur. So ist /
+das Wurzelverzeichnis, von dem aus in Unterverzeichnisse
+verzweigt wird. /boot, /root, /opt, /usr, /var, /tmp,
+/etc, /bin sind Standardverzeichnisse in dieser Struktur.
+In HTML wird der Slash benutzt, um Tags zu schliessen.
+&lt;html>
+&lt;head>&lt;title> Homepagetitel &lt;/title>&lt;/head>
+&lt;body>
+Seitentext inklusive weiterer HTML-Befehle.
+&lt;/body>
+&lt;/html>
+Dies ist eine gültige Grundstruktur einer HTML-Seite mit
+sehr wenig Inhalt.</text>
+  </lesson>
+  <lesson>
+   <id>{d002e8c0-6db1-4c4e-be34-26ffe7f2c5f9}</id>
+   <title>4, $, 9 und )</title>
+   <newCharacters>4$9)</newCharacters>
+   <text>(49$) (49$) (48$) (57$) (56$) (78$) (89$) (18$) ($81) (51$)
+Das $-Zeichen steht für Dollar. Jedem ist klar, dass dieses
+Zeichen für eine Währung steht, die den Weltmarkt beherrst.
+Dies soll jetzt kein Text über Umrechnungskurse werden. Die
+wechseln ja doch regelmässig. Stattdessen wollen wir auch
+für dieses $-Zeichen nach weiteren Bedeutungen fahnden.
+Zunächst die Bash:
+$ steht für Variablen- oder Befehlssubstitution.
+Beispiel für Befehlssubstitution: Befehl1 $(Befehl2)
+Beispiele für Variablensubstitution können hier leider noch
+nicht geschrieben werden, da dabei die geschweifte Klammer
+verwendet wird.
+Und nun Perl:
+In Perl lassen sich mit dem $-Zeichen ganz einfach Variablen
+festlegen. Mit
+chomp($eingabe);
+wird das Newline-Zeichen am Ende der Eingabe entfernt.
+Dabei wird der Inhalt der Variablen $eingabe bereits ausge-
+lesen und verarbeitet.</text>
+  </lesson>
+  <lesson>
+   <id>{8cb0ef48-00da-4a89-bbe6-7e59772d62bc}</id>
+   <title>3, §, 0 und =</title>
+   <newCharacters>3§0=</newCharacters>
+   <text>§30=§30=§30=§30=§30=§30=§30=§30=§30=§30=§30=§30=§30=§30=§30
+134567890 098765431 !§$%&amp;/()= =)(/&amp;%$§! 890 60 470 160 3140
+
+§ - Paragraph
+Dieses Zeichen steht für Recht und Ordnung auf der ganzen
+Welt. Sie kennen das:
+§1 Jeder macht seins.
+§2 Wenn keine anderen Paragraphen entgegenstehen, gilt §1!
+
+Selbst das Wort Paragraphenreiter kommt nicht von ungefähr.
+Schliesslich sieht § aus wie ein Seepferdchen.
+
+Das = (in Worten: ist gleich) steht ebenfalls für Gerech-
+tigkeit. Eine Gleichung ist nur dann eine wahre Aussage,
+wenn die Kräfte (Terme?, Werte?) auf beiden Seiten gerecht
+verteilt sind.
+ 2-1=1
+ 4-2=2
+ 91347-34567=56780
+ f(x)=3x-7
+In der Programmierung nimmt man mit = oder == eine Zuwei-
+sung vor.
+ $eingabe = &lt;STDIN>
+
+Schlimmstenfalls lässt sich das = aber schön als Trennzei-
+chen für Textabsätze verwenden.
+</text>
+  </lesson>
+  <lesson>
+   <id>{0d0ffc2e-661d-49c2-a0f4-f970858e33b7}</id>
+   <title>"</title>
+   <newCharacters>"</newCharacters>
+   <text>ALLES WAS HIER STEHT IST, MIT FESTGESTELLTER UMSCHALTTASTE
+1234567890 0987654321 20 21 22 23 24 25 26 27 28 29 2222 2
+"Dies ist eine Aussage!"
+Die "Gänsefüsschen" werden in der Schriftsprache verwendet,
+um wörtliche Rede deutlich zu machen. So kann man zum Bei-
+spiel ab sofort nicht nur sagen, dass Kafka darüber etwas
+las, wie man etwas sagt, sondern man kann nun auch schrei-
+ben Kafka las:"Ich sage ihnen mal wie man das sagt!"
+Darauf antwortete das Publikum:"Nee, lass mal!"
+Wie in "Gänsefüsschen" werden die "Gänsefüsschen" manchmal
+auch dazu verwendet, um eine nicht ganz korrekte aber ge-
+läufige Bezeichnung zu verwenden. Schliesslich sehen es
+die Gänse nicht gern, wenn man ihre Füsse mit einfachen An-
+führungsstrichen vergleicht.
+Eine Aussage im Computerbereich ist ähnlich einer Aussage
+im literarischen Bereich häufig in Anführungsstriche zu
+setzen. echo "Dies ist ein Text!" bringt in der Bash
+Dies ist ein Text!
+zum Vorschein. Eingebaut als Warnungen in Scripte in der
+Form
+echo "Konnte den User nicht anlegen!"
+Führt das zu sinnvollen Ausgaben, die zur rechten Zeit
+das richtige sagen.</text>
+  </lesson>
+  <lesson>
+   <id>{405ff01c-a162-4ad7-b12b-e5066911c2ef}</id>
+   <title>+, *, # und '</title>
+   <newCharacters>+*#'</newCharacters>
+   <text>+*#' +*#' +'*# #*#' *#' #+'+ +##+ '++' ++'#*# #+#+#+#+* #*
+  3+3=6
+  3*3=9
+ #include &lt;gtk.h>
+ # dies ist ein Kommentar
+ ## dies auch
+c++ ist eine objektorientierte Programmiersprache.
+g++ ist nichts anderes.
+Berechne!
+  3+3+3+3=
+  3*3*3*3=
+  9*9*9*9=
+  9+9+9+9=
+Rechenoperationen in der Mathematik:
+  + ist das Zeichen für die Addition.
+  * ist das Zeichen für Multiplikation.
+'Hier steht etwas drin!'
+In literarischen Texten wird das Zeichen ' häufig dafür
+verwendet, um eine wörtliche Rede: ("Du hast doch gesagt,
+dass ich den Film noch zuende sehen darf.") von Gedanken,
+die nicht ausgesprochen werden ('Immer muss ich um acht
+ins Bett! Das ist echt unfair!') zu unterscheiden.
+So kann man sehr sinnreiche Texte formulieren, in denen
+man genau darauf achten muss, was gesagt und was nur ge-
+dacht wurde.
+"Ein schönes Kleid haben sie heute wiede an, Frau Meier!"
+'Den Fummel haben sie wohl aus dem Schlussverkauf, oder?'</text>
+  </lesson>
+  <lesson>
+   <id>{06ba9efd-8525-4f69-b7aa-397745e71c75}</id>
+   <title>_, ^, °, ' und `</title>
+   <newCharacters>_ ^ ° '  `</newCharacters>
+   <text>^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^
+° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° ° °
+' ' ' ' ' ' ' ' ' ' ' ' ' ' ' ' ' ' ' ' ' ' ' ' ' ' ' ' '
+` ` ` ` ` ` ` ` ` ` ` ` ` ` ` ` ` ` ` ` ` ` ` ` ` ` ` ` `
+Heute werden Tageshöchsttemperaturen von 21°C erwartet.
+Bei 0°C liegt der Gefrierpunkt des Wassers.
+Wasser siedet bei 100 °C.
+Das ^ ist ein Sonderzeichen, das z.B. beim Programmieren
+in C++ das Bit-Exclusive-ODER XOR repräsentiert.
+^ ist dort also ein Operator.
+` (Backquotes) werden in Perl wie in einer Shell dazu
+verwendet, Ausgaben eines Programms als Daten zu über-
+nehmen.
+$jetzt = "Die aktuelle Uhrzeit ist ".`date`
+foreach $_ (`who`) ...</text>
+  </lesson>
+  <lesson>
+   <id>{19b122b4-7b9f-4c4d-9d86-8896d1119680}</id>
+   <title>Zwischenübung</title>
+   <newCharacters></newCharacters>
+   <text>Sitzung
+frei erschwindelt von A. Kalbitz
+
+"Hast du dir das auch gut überlegt?" Rainer schaute zwei-
+felnd auf Felix und man sah seinen Augen an, dass da nicht
+nur Zweifel, sondern auch besseres Wissen in dieser Frage
+lag. "Aeh, ich dachte, ja,", kam Felix zögerlich mit der
+Sprache raus, "wenn ich schon Linux auf dem Schulnetz fah-
+re, dann sollen auch die Schüler die Möglichkeit haben,
+mit Linux zu arbeiten." Rainer sah immer noch skeptisch
+aus. "Dann bist Du aber erst einmal der Einzige, der das
+benutzen und den Schülern verständlich machen kann."
+"Das ist schon klar, aber ich bin guter Hoffnung, das
+das System so nach und nach überzeugt!" -
+"Und die Kollegen?" - "Bekommen eine Schulung, wenn der
+Bedarf da ist." - "Na gut, wenn Du glaubst, dass das so
+machbar ist, dann gehen wir es an, ich bezweifle nur,
+dass du damit viele erreichen wirst." Felix grinste nun
+breit übers ganze Gesicht: "Warten wir es doch ab."
+Nun sah er aus, als hätte er ein As aus dem Aermel gezogen.
+"Wir haben bisher niemanden dazu überredet, sich einen
+Computer "anzutun", und selbst unter den älteren Kollegen
+wird die Zahl derjenigen, die diese Technik akzeptieren
+nun doch immer grösser, warum soll sich dass denn mit dem
+interessantesten System, das die Branche zu bieten hat
+nicht bald ähnlich einstellen. Letztendlich setzt sich die
+Neugierde doch durch." Nun grinste auch Rainer, "Na gut,
+ich kaufe mir schon mal für meinen privaten Rechner eine
+neue Festplatte, damit ich dann mitreden kann, wenn es
+losgeht." - "Siehste! Es wirkt schon!" ;-)</text>
+  </lesson>
+  <lesson>
+   <id>{9637c6f2-f6c7-45d3-b0c0-1af06897375f}</id>
+   <title>², ³, {, [, ], }, \, @, ~ und |</title>
+   <newCharacters>{[]}\@~|</newCharacters>
+   <text>Drittbelegung: Das sind die Zeichen { [ ] } \ @ ~ |
+"geschweifte" und "eckige" Klammern:
+  {} []
+  y={3x*[2x-1]-4}
+  if test "${!arg_num}" = "-v"; then
+    verbose on
+"Backslash":
+  \ wir verwendet, um eine Befehlszeile in einem
+  Script auf der foldenden Zeile weiterzuführen.
+"Klammeraffe":
+  @ kommt in E-Mailadressen vor.
+  moritz@musterdomain.de
+  user@localhost
+  @ Wird z.B. in Perl für zur Festlegung von
+  Arrays oder als Feldplatzhalter verwendet.
+  @nonsens("Quatsch","Witz","Blödsinn")
+  @&lt;&lt;&lt;&lt;&lt;&lt;&lt;
+"Tilde":
+  ~ dient z.B. standardmässig als Kennzeichnung für
+  Sicherheitskopien, die von ln angelegt werden.
+"Pipe":
+  | wird als arithmetischer Ausdruck für bitweises
+  ODER z.B. in der bash verwendet.
+  || hingegen kennzeichnet ein logisches ODER
+  |= ist ein ODER mit anschliessender Zuweisung
+  Mit | lassen sich Ausgaben eines Befehls in
+  andere Anwendungen umleiten.
+  ls *.jpg | less listet alle Dateien des aktuellen
+  Verzeichnisses in less auf.
+Die Zeichen der Drittbelegung haben mit der Einführung des
+Computers in das Leben der Schreibenden Einzug gehalten.
+Aus diesem Grund haben wir sie in den Kurs aufgenommen.
+Im ursprünglichen Zehnfinger-System gibt es keine
+Entsprechung, da auf alten Schreibmaschinen die &lt;Alt Gr>-
+Taste nicht existiert.
+{@@@} || {@@@} || [@@@] || [@@@] || \\\ || @@@ || ~~~ ||</text>
+  </lesson>
+  <lesson>
+   <id>{0873b22f-d9b9-4bd4-9c8e-27f0c33aee49}</id>
+   <title>Geschafft</title>
+   <newCharacters></newCharacters>
+   <text>/* info.cpp - description
+ *
+ * begin: Sun Jan 30 14:40:59 MET 2000
+ * copyright: (C) 1999 by Daniel Reith
+ * email: DanR@gmx.de
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General
+ * Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ */
+
+#include "info.h"
+#include "wx/image.h"
+#include &lt;config.h>
+
+enum
+{
+  C = 211,
+  OK = 212
+};
+
+BEGIN_EVENT_TABLE(Info_Dialog, wxDialog)
+  EVT_BUTTON(OK, Info_Dialog::OnSchliessen)
+END_EVENT_TABLE()
+
+// Konstruktor
+Info_Dialog::Info_Dialog(wxWindow* parent, wxWindowID id,
+    const wxString&amp; title,
+    const wxPoint&amp; pos = wxDefaultPosition,
+    const wxSize&amp; size = wxDefaultSize,
+    long style = wxDEFAULT_DIALOG_STYLE,
+    const wxString&amp; name = "dialogBox")
+ :  wxDialog(parent, id, title, pos, size, style, name)
+{
+  SetAutoLayout(TRUE);
+ #ifdef __WXMSW__
+  wxBitmap::AddHandler(new wxPNGFileHandler);
+ #endif
+ #ifdef __WXGTK__
+  wxImage::AddHandler(new wxPNGHandler);
+ #endif
+  wxString f;
+  f &lt;&lt; L_DIR &lt;&lt; "logo.png";
+  logo = new wxBitmap(f , wxBITMAP_TYPE_PNG);
+  canvas = new MyCanvas(this,  logo, wxDefaultPosition,
+      wxDefaultSize);
+  wxLayoutConstraints *c1 = new wxLayoutConstraints;
+  c1->top.SameAs(this, wxTop, 5);
+  c1->left.SameAs(this, wxLeft, 5);
+  c1->width.PercentOf(this, wxWidth, 48);
+  c1->height.PercentOf(this, wxHeight, 80);
+  canvas->SetConstraints(c1);
+  info_text = new wxStaticText(this, -1, "",
+      wxDefaultPosition, wxDefaultSize);
+  wxLayoutConstraints *c3 = new wxLayoutConstraints;
+  c3->top.SameAs(this, wxTop, 5);
+  c3->left.SameAs(canvas, wxRight, 15);
+  c3->width.PercentOf(this, wxWidth, 47);
+  c3->height.PercentOf(this, wxHeight, 80);
+  info_text->SetConstraints(c3);
+  wxString msg;
+  msg &lt;&lt; _("PingoS Tipptrainer\n")
+      &lt;&lt; _("------------------\n")
+      &lt;&lt; _("Version:\t") &lt;&lt; VERSION &lt;&lt; _("\n")
+      &lt;&lt; _("http://www.pingos.schulnetz.org/tipptrainer\n")
+      &lt;&lt; _("Veröffentlicht unter der GPL 2.0\n\n")
+      &lt;&lt; _("Autoren:\n")
+      &lt;&lt; "Andreas Kalbitz\n"
+      &lt;&lt; "\t(felix@musik-workshop.de)\n"
+      &lt;&lt; "Matthias Kleine\n"
+      &lt;&lt; "\t(Matthias.Kleine@selflinux.de)\n"
+      &lt;&lt; "Daniel Reith (DanR@gmx.de)\n"
+      &lt;&lt; _("\nFeedback bitte an:\n")
+      &lt;&lt; _(\ttipptrainer@reith.8m.com");
+  info_text->SetLabel(msg);
+  ok = new wxButton(this, OK, _("Schliessen"));
+  wxLayoutConstraints *c2 = new wxLayoutConstraints;
+  c2->centreX.SameAs(this, wxCentreX);
+  c2->top.SameAs(canvas, wxBottom, 10);
+  c2->width.PercentOf(this, wxWidth, 30);
+  c2->height.PercentOf(this, wxHeight, 9);
+  ok->SetConstraints(c2);
+}
+
+// Destruktor
+Info_Dialog::~Info_Dialog()
+{
+}
+
+// Fenster schliessen
+void Info_Dialog::OnSchliessen(wxCommandEvent* event)
+{
+  EndModal(GetReturnCode());
+}
+BEGIN_EVENT_TABLE(MyCanvas, wxScrolledWindow)
+    EVT_PAINT(MyCanvas::OnPaint)
+END_EVENT_TABLE()
+MyCanvas::MyCanvas(wxWindow *parent, wxBitmap *b,
+    const wxPoint&amp; pos, const wxSize&amp; size)
+ :  wxScrolledWindow(parent, -1, pos, size)
+{
+  logo = b;
+}
+
+MyCanvas::~MyCanvas()
+{
+}
+
+void MyCanvas::OnPaint(wxPaintEvent&amp; WXUNUSED(event))
+{
+  wxPaintDC dc(this);
+  wxMemoryDC memDC;
+  memDC.SelectObject(* logo);
+  dc.Blit(5, 25, logo->GetWidth(), logo->GetHeight(),
+      &amp; memDC, 0, 0, wxCOPY, TRUE);
+  memDC.SelectObject(wxNullBitmap);
+}</text>
+  </lesson>
+ </lessons>
+</course>

--- a/data/data.xml
+++ b/data/data.xml
@@ -89,6 +89,26 @@ Version: 0.1 beta</description>
     <path>courses/de2.xml</path>
   </course>
   <course>
+    <title>Deutsch (CH)</title>
+    <description>Deutscher Kurs f&#xFC;r KTouch von Markus Frisch &lt;frisch@vr-web.de&gt; (Modified for Swiss keyboard layout)</description>
+    <keyboardLayout>ch</keyboardLayout>
+    <id>{7361fd17-5457-48e1-b118-a59a429c734b}</id>
+    <path>courses/ch1.xml</path>
+  </course>
+  <course>
+    <title>Deutsch (CH - aus Tipptrainer)</title>
+    <description>German training file
+adapted by Sven Gohlke &lt;sven@clio.in-berlin.de&gt;
+for ktouch from a training file distributed by
+Andreas Kalbitz  &lt;felix@pingos.schulnetz.org&gt;
+for Tipptrainer V0.4 http://www.pingos.schulnetz.org/tipptrainer
+distributed under the GPL2
+Version: 0.1 beta (Modified for Swiss keyboard layout)</description>
+    <keyboardLayout>ch</keyboardLayout>
+    <id>{90a0ad22-18e7-484f-b1cd-6babdd0f7037}</id>
+    <path>courses/ch2.xml</path>
+  </course>
+  <course>
     <title>Dansk</title>
     <description>Tr&#xE6;ningsfil udviklet af
 Gunther Strube,  gstrube@tiscali.dk og


### PR DESCRIPTION
Add courses for Swiss German keyboard layout (ch), using a copy of two courses for German, but with keys which are not on a Swiss German keyboard (double s, capital letters with umlaut, square and cube) removed or replaced.