### PR TITLE
Correct spelling mistake

### DIFF
--- a/data/courses/it.xml
+++ b/data/courses/it.xml
@@ -594,7 +594,7 @@ non videro neanche l'ombra del lupo. Il pastorello
 rideva a crepapelle:
 "Era solo uno scherzo e voi ci siete cascati!!!"
 Qualche giorno dopo ripet&#xE9; lo stesso e i contadini
-allarmati giunsero di corsa la prato.
+allarmati giunsero di corsa al prato.
 Presto si accorsero che il pastorello si era
 giocato un'altra volta di loro.
 Un giorno arriv&#xF2; d'improvviso un intero branco di


### PR DESCRIPTION
di corsa *la* prato → di corsa *al* prato.