### PR TITLE
Alternative (better) Italian translation of the fable

### DIFF
--- a/data/courses/it.xml
+++ b/data/courses/it.xml
@@ -661,18 +661,18 @@ deluso e vinto si nascose in un luogo lontano.</text>
     </lesson>
     <lesson>
       <id>{c2edeecf-3092-4809-8540-6d044233f902}</id>
-      <title>L'aquila e lo scarafaggio</title>
+      <title>L'aquila e lo scarabeo</title>
       <newCharacters/>
       <text>Un'aquila inseguiva una lepre per catturarla.
 Questa non sapeva come trovare aiuto; cos&#xEC;, visto
-uno scarafaggio, il solo essere in cui il caso la
+uno scarabeo, il solo essere in cui il caso la
 fece imbattere, si diede a supplicarlo. Lo
-scarafaggio la rassicur&#xF2; e, appena l'aquila gli si
+scarabeo la rassicur&#xF2; e, appena l'aquila gli si
 avvicin&#xF2;, prese a scongiurarla perch&#xE9; non gli
 portasse via la povera lepre. Ma l'aquila non si
 cur&#xF2; di quel piccolo insetto nero e divor&#xF2; la
 lepre proprio sotto i suoi occhi.
-Memore dell'offesa, lo scarafaggio, da allora,
+Memore dell'offesa, lo scarabeo, da allora,
 prese a seguire l'aquila con costanza: osservava i
 luoghi dove quella faceva il nido e deponeva le
 uova; volava al nido, si posava sulle uova e le
@@ -681,14 +681,14 @@ Cacciata da tutti i luoghi, l'aquila un giorno si
 rivolse a Giove e lo preg&#xF2; di procurarle un luogo
 sicuro, dove poter fare le sue covate. Giove le
 permise di deporre le uova nel proprio grembo. Ma
-lo scarafaggio ide&#xF2; uno stratagemma: fece una
+lo scarabeo ide&#xF2; uno stratagemma: fece una
 pallottola di sterco, vol&#xF2; sopra il grembo di
 Giove e ve lo lasci&#xF2; cadere.
 Il dio, per liberarsi da quella sporcizia, si alz&#xF2;
 in piedi con uno scatto e, senza rendersene conto,
 fece cadere a terra le uova.
 Da quel tempo, si dice che nella stagione in cui
-appaiono gli scarafaggi le aquile non facciano il
+appaiono gli scarabei le aquile non facciano il
 nido.</text>
     </lesson>
     <lesson>


### PR DESCRIPTION
scarafaggio (cockroach) → scarabeo ([dung] beetle)
The tale uses the latter on most authoritative websites and sources on- and offline