### PR TITLE
Remove leading white-space in US lesson file.

### DIFF
--- a/data/courses/us.xml
+++ b/data/courses/us.xml
@@ -7,611 +7,611 @@ Perl Script written by Steinar Theigmann and H&#xE5;vard Fr&#xF8;iland.</descrip
   <keyboardLayout>us</keyboardLayout>
   <lessons>
     <lesson>
-      <id>{591b9566-d988-4714-87e2-a5cfe4647440}</id>
-      <title>j and f</title>
-      <newCharacters>jf</newCharacters>
-      <text>ff jjj jf jfj j jff fjjf ff jfj j jff ff jjj fjj fjj fjf
-      jfj jjj f fjjf jjj fjjf jfj fjjf f j fjj jff j fjj jf jjj fjjf f
-      f fjf fjjf jff jjj ff jf fjjf fjjf f fjj fjj jf fjf j jj f j fjj
-      jj jjj f jjj f fjjf j j jjj f j jjj jj ff fjf fjj f f ff jjj jj
-      fjf f ff f fjjf fjj fjj f j fjf f jj jj jff jj jfj f jf jjj fjj
-      j jjj jfj fjjf f f fjf jj ff f j fjf fjj f jf j jf j fjj fjjf jj
-      jff f jff jff j f j f jff f jjj j fjf f fjjf j jff jj j f jf j
-      ff jj fjj ff jfj jfj j ff fjjf jj ff fjj f jff jff f fjf jj jj f
-      jfj j fjj jjj jff jj fjj jfj f fjj fjjf jj jj jf jff ff f jf jj
-      ff fjjf j jff fjf f f jfj fjjf f jj j fjj j fjj jf f f j ff jj j
-      fjf jfj jj jj jf j f j ff j fjjf jff f fjj jff j jf fjf j fjjf
-      fjj j jj jf fjj jfj jfj fjjf f f jjj jj fjj fjjf j fjjf jf fjjf
-      jf f fjj j j jjj jj jf j ff fjf jj jjj ff jf j jjj f ff ff j jf
-      jjj jff jff f jf j jfj fjj jfj fjjf fjj fjjf fjjf jj jjj ff jfj
-      j jj f jj jfj jff f f j j j f f jj jjj f fjj j fjjf fjj f fjjf
-      fjf ff f jf fjjf fjj fjj j f jf f fjjf ff jf ff jff jf j fjf f
-      fjjf fjj j jff jj f jf f fjjf jf jjj f fjjf fjjf j j f jfj f jjj
-      j f fjjf f j jj jj fjj fjjf f f jff jj jff f j jff f ff fjjf jf
-      fjj fjj jf j jff fjf jj jj jj jfj jf j jfj j fjjf jff ff fjj f j
-      f j f f jj f fjj jf jjj fjjf j f f jj jj jjj ff j fjf f fjj jfj
-      jfj fjf jj jjj j fjj jj jfj jjj jj jj f j j jff jjj jjj f jj jff
-      f f f f fjf fjjf jff j jjj fjjf ff fjjf j j fjf fjj jj j fjjf f
-      jjj jfj jj fjjf fjf fjj jjj j j jjj jf f f j fjj fjjf jfj fjj f
-      ff j j jj jf jj jfj jff fjj jf jj jf jf jj jj f fjjf jf j f fjjf
-      ff jjj jf fjf jj fjjf f jff f j ff fjj j fjj jj fjj jj jf j fjjf
-      j jfj ff jf jf fjj ff j ff f jj ff jfj jj j jfj jj f jj jj jf jf
-      jj jjj jfj j jfj jjj jfj jf jjj j j jf jfj fjj f jfj fjj ff jff
-      fjj f j jjj jf f jff fjf jf f jj j f j f jff ff jf jfj jjj jf ff
-      ff jff f fjj jfj j jfj jj jjj jf f fjjf j ff jjj jfj jff jff f
-      fjjf fjj fjjf f jfj jj f ff jff fjjf jff f jjj jfj jj j jfj ff
-      fjj ff j f jj fjjf</text>
+<id>{591b9566-d988-4714-87e2-a5cfe4647440}</id>
+<title>j and f</title>
+<newCharacters>jf</newCharacters>
+<text>ff jjj jf jfj j jff fjjf ff jfj j jff ff jjj fjj fjj fjf
+jfj jjj f fjjf jjj fjjf jfj fjjf f j fjj jff j fjj jf jjj fjjf f
+f fjf fjjf jff jjj ff jf fjjf fjjf f fjj fjj jf fjf j jj f j fjj
+jj jjj f jjj f fjjf j j jjj f j jjj jj ff fjf fjj f f ff jjj jj
+fjf f ff f fjjf fjj fjj f j fjf f jj jj jff jj jfj f jf jjj fjj
+j jjj jfj fjjf f f fjf jj ff f j fjf fjj f jf j jf j fjj fjjf jj
+jff f jff jff j f j f jff f jjj j fjf f fjjf j jff jj j f jf j
+ff jj fjj ff jfj jfj j ff fjjf jj ff fjj f jff jff f fjf jj jj f
+jfj j fjj jjj jff jj fjj jfj f fjj fjjf jj jj jf jff ff f jf jj
+ff fjjf j jff fjf f f jfj fjjf f jj j fjj j fjj jf f f j ff jj j
+fjf jfj jj jj jf j f j ff j fjjf jff f fjj jff j jf fjf j fjjf
+fjj j jj jf fjj jfj jfj fjjf f f jjj jj fjj fjjf j fjjf jf fjjf
+jf f fjj j j jjj jj jf j ff fjf jj jjj ff jf j jjj f ff ff j jf
+jjj jff jff f jf j jfj fjj jfj fjjf fjj fjjf fjjf jj jjj ff jfj
+j jj f jj jfj jff f f j j j f f jj jjj f fjj j fjjf fjj f fjjf
+fjf ff f jf fjjf fjj fjj j f jf f fjjf ff jf ff jff jf j fjf f
+fjjf fjj j jff jj f jf f fjjf jf jjj f fjjf fjjf j j f jfj f jjj
+j f fjjf f j jj jj fjj fjjf f f jff jj jff f j jff f ff fjjf jf
+fjj fjj jf j jff fjf jj jj jj jfj jf j jfj j fjjf jff ff fjj f j
+f j f f jj f fjj jf jjj fjjf j f f jj jj jjj ff j fjf f fjj jfj
+jfj fjf jj jjj j fjj jj jfj jjj jj jj f j j jff jjj jjj f jj jff
+f f f f fjf fjjf jff j jjj fjjf ff fjjf j j fjf fjj jj j fjjf f
+jjj jfj jj fjjf fjf fjj jjj j j jjj jf f f j fjj fjjf jfj fjj f
+ff j j jj jf jj jfj jff fjj jf jj jf jf jj jj f fjjf jf j f fjjf
+ff jjj jf fjf jj fjjf f jff f j ff fjj j fjj jj fjj jj jf j fjjf
+j jfj ff jf jf fjj ff j ff f jj ff jfj jj j jfj jj f jj jj jf jf
+jj jjj jfj j jfj jjj jfj jf jjj j j jf jfj fjj f jfj fjj ff jff
+fjj f j jjj jf f jff fjf jf f jj j f j f jff ff jf jfj jjj jf ff
+ff jff f fjj jfj j jfj jj jjj jf f fjjf j ff jjj jfj jff jff f
+fjjf fjj fjjf f jfj jj f ff jff fjjf jff f jjj jfj jj j jfj ff
+fjj ff j f jj fjjf</text>
     </lesson>
     <lesson>
-      <id>{051431ae-badf-4b91-b2ce-e653a5dd5225}</id>
-      <title>k and d</title>
-      <newCharacters>kd</newCharacters>
-      <text>jjd fdfj rd djd jk jd k dd fjk fd fk k jfkd dkkf fk dkd dd
-      jk k dfj djd fkkk fk dff d dkkf fd fk fdfj fk k dkkf djd dff dkd
-      dff dkd kdk k dkkf k jk fkkk jd k jfkd fk fk jd k d dkd jd k dd
-      rd dffd d fk k k dff dff dd fk fk fd jd dd jjd rd dkd dkf kdk
-      fdfj d kdk djd k fk rd dd fk dff dff kdk dkd dkf d k jk jfkd jd
-      jfkd d kdk dkd kdk djd jd dkf dkkf fkkk dd djd fd dkf fk dff
-      dkkf fk fk fdfj fk fk rd jjd k k dkkf d rd dkd dd rd jjd fk fd
-      fk k jk rd fd fd djd k jjd djd fk k fjk k dd dfj kdk jd djd fk
-      dfj fd k dffd jd djd kdk dkd dd k fd fk jjd fjk fd rd fjk fk k
-      dfj fd dd dkd d k dd kdk fjk fk dkkf dd dkkf dd rd fd jd k jjd k
-      dkf djd dkf k dkd d jd d fjk dkkf dffd k d fdfj djd kdk fkkk d
-      dfj jk fk jd jfkd jd kdk dffd dd dkf dffd jk jk jd fd dkf k jd
-      jfkd fdfj fkkk k dkf fdfj dfj fd jd jd dd dd jd dd rd dkd dffd
-      fd fkkk dffd dd fk jjd fk k k d dfj fdfj k fk fk dkd dkkf dffd
-      dffd k fkkk dkf jk dkd fdfj jfkd jd dd jk fd dkf dkd dd k d k
-      fdfj fdfj dd dffd djd dffd kdk dffd fd jk dffd fk fd rd fdfj d
-      fk d dff fkkk fk fk jd fkkk djd fk fdfj jd jfkd dkkf fkkk dkkf
-      kdk dd dfj k fk dfj fk jk fd jd k k kdk k dfj dd k jfkd d fk jk
-      rd fk k dffd fk djd jjd fk dkd dd dffd fk fk kdk fdfj dfj fd fk
-      dd dffd dd dkd fkkk k dkf dkkf k jfkd d dfj k fk fdfj dff fk djd
-      dd d dff k fd rd fdfj fk fd dkd djd kdk fk fk dfj fk fdfj k dkf
-      dkkf dffd k fk fk jfkd jk dffd fd dff fk dkf fk dffd jd dfj d
-      dkkf jd jjd fd fjk fd fk fk dff dffd fdfj dkkf fd jd jfkd dffd d
-      djd dkd fdfj fk dff fk fdfj jk fk dfj d dkf rd rd jd rd jfkd dd
-      jd k dffd fd dkd fk fk k dkd djd fk jjd jjd k dd dd jd fk fk fk
-      jfkd fd d fk fk d fkkk dkkf jjd dkf fdfj fkkk djd k fk k jd dd
-      dkd djd k kdk rd djd k jjd k jd dfj dfj dkf jjd fk fd rd jd fdfj
-      jk fk fjk rd k jd dkf rd dkd fkkk jfkd jjd jjd fk jd fk jk dfj d
-      fkkk k jjd jk fjk dd rd jd fdfj jd dfj jk dkkf fkkk fk fk dffd
-      fk dfj jd dd jk dfj fjk fd jfkd fk fd jd fd jd k dffd rd dkd dd
-      fk fk jk dffd fk dkd fjk jk k jk djd fdfj fk dd jd</text>
+<id>{051431ae-badf-4b91-b2ce-e653a5dd5225}</id>
+<title>k and d</title>
+<newCharacters>kd</newCharacters>
+<text>jjd fdfj rd djd jk jd k dd fjk fd fk k jfkd dkkf fk dkd dd
+jk k dfj djd fkkk fk dff d dkkf fd fk fdfj fk k dkkf djd dff dkd
+dff dkd kdk k dkkf k jk fkkk jd k jfkd fk fk jd k d dkd jd k dd
+rd dffd d fk k k dff dff dd fk fk fd jd dd jjd rd dkd dkf kdk
+fdfj d kdk djd k fk rd dd fk dff dff kdk dkd dkf d k jk jfkd jd
+jfkd d kdk dkd kdk djd jd dkf dkkf fkkk dd djd fd dkf fk dff
+dkkf fk fk fdfj fk fk rd jjd k k dkkf d rd dkd dd rd jjd fk fd
+fk k jk rd fd fd djd k jjd djd fk k fjk k dd dfj kdk jd djd fk
+dfj fd k dffd jd djd kdk dkd dd k fd fk jjd fjk fd rd fjk fk k
+dfj fd dd dkd d k dd kdk fjk fk dkkf dd dkkf dd rd fd jd k jjd k
+dkf djd dkf k dkd d jd d fjk dkkf dffd k d fdfj djd kdk fkkk d
+dfj jk fk jd jfkd jd kdk dffd dd dkf dffd jk jk jd fd dkf k jd
+jfkd fdfj fkkk k dkf fdfj dfj fd jd jd dd dd jd dd rd dkd dffd
+fd fkkk dffd dd fk jjd fk k k d dfj fdfj k fk fk dkd dkkf dffd
+dffd k fkkk dkf jk dkd fdfj jfkd jd dd jk fd dkf dkd dd k d k
+fdfj fdfj dd dffd djd dffd kdk dffd fd jk dffd fk fd rd fdfj d
+fk d dff fkkk fk fk jd fkkk djd fk fdfj jd jfkd dkkf fkkk dkkf
+kdk dd dfj k fk dfj fk jk fd jd k k kdk k dfj dd k jfkd d fk jk
+rd fk k dffd fk djd jjd fk dkd dd dffd fk fk kdk fdfj dfj fd fk
+dd dffd dd dkd fkkk k dkf dkkf k jfkd d dfj k fk fdfj dff fk djd
+dd d dff k fd rd fdfj fk fd dkd djd kdk fk fk dfj fk fdfj k dkf
+dkkf dffd k fk fk jfkd jk dffd fd dff fk dkf fk dffd jd dfj d
+dkkf jd jjd fd fjk fd fk fk dff dffd fdfj dkkf fd jd jfkd dffd d
+djd dkd fdfj fk dff fk fdfj jk fk dfj d dkf rd rd jd rd jfkd dd
+jd k dffd fd dkd fk fk k dkd djd fk jjd jjd k dd dd jd fk fk fk
+jfkd fd d fk fk d fkkk dkkf jjd dkf fdfj fkkk djd k fk k jd dd
+dkd djd k kdk rd djd k jjd k jd dfj dfj dkf jjd fk fd rd jd fdfj
+jk fk fjk rd k jd dkf rd dkd fkkk jfkd jjd jjd fk jd fk jk dfj d
+fkkk k jjd jk fjk dd rd jd fdfj jd dfj jk dkkf fkkk fk fk dffd
+fk dfj jd dd jk dfj fjk fd jfkd fk fd jd fd jd k dffd rd dkd dd
+fk fk jk dffd fk dkd fjk jk k jk djd fdfj fk dd jd</text>
     </lesson>
     <lesson>
-      <id>{b6c4526a-847b-4e78-b233-c9367469e415}</id>
-      <title>l and s</title>
-      <newCharacters>ls</newCharacters>
-      <text>fl s l ldk l s slj s dks sf kl ll ls l ls dss lkj slk ks
-      jl jjss l slj jl lkj l ldf s ld ll l ll ldk jjdl dlkk fl rs dss
-      fld fl kl fl fl lkj fld ld fld js l dss kl jl jl ldk fld s ls s
-      js kl ll ld dss fld l rs sf dss ll jl kl ls slj kl ldf kl dss rs
-      ls js s dlkk js kl js ls fld jl jjdl ll jjdl ll rs ldf rs ld ldk
-      slj slj fl fld lkj rs ldf dlkk dss rs fl ld ldk kl dks fl sf dks
-      ldk slj kl sf dlkk fl s kl l ll fl slj ll s s s dds s sf fld ks
-      ks s ll dss s sf dks fl ldf dks rs ld s jjss ll l slk kl dks sf
-      ll ldf s ll dlkk rs jl l ll ls l ldk ldk js dss rs s slj l dks
-      fld jl ks dss dlkk ls kl ks kl js kl ldk kl ls l slk dlkk lkj
-      slj dks ld dks rs ldf dlkk ls s rs jjdl slk ldk slk dds lkj lkj
-      s jjdl fl l s kl slk jjss ls ll dss sf slj dlkk jl fl kl fl jl
-      rs ls ll lkj lkj ls lkj kl fl fl ll fl dks l dlkk kl s ldk fl fl
-      ks l kl ldf js slk fld dds l ldk ll dlkk jjss l lkj slk jl fl
-      ldf ll fl l fl jjss ls ldk ll dks kl slj ldf kl dlkk slk jjdl sf
-      dlkk dlkk fld ld s ls dlkk ld kl jl kl fl ls kl ls kl l sf l ls
-      ldf dlkk kl sf fl ks lkj fl jjdl ldk ls jjdl dlkk dlkk ldk rs sf
-      slj ld s l js ldf fld ldf dks ks ll jjdl slj fld dlkk s js l
-      jjdl s s ks ld ll lkj dds ldk ls fl ldk dss jl sf fld kl rs rs
-      ll ldf s dks ls ls dds slj dlkk jl l slk sf dks dks rs ldk jl
-      dks l dlkk l ks rs ks dks ks fld dds dss ldk kl s ks dks slk fl
-      slj dds fl s js jjss kl dks s fl rs s rs ldf ls sf ls ll rs sf
-      dds dss jjdl l slk ldk rs kl ld ll kl ll fl jjss ls ldf ll jjss
-      kl ll jjdl jjss sf ld jjdl ks ld js l slj jjdl fl sf lkj kl rs
-      jjdl ks s dds dss fl slk ll l l slj fl dss js lkj fld ks lkj ks
-      ldk jjss ll ld l kl js fl rs ls s s sf dds jl fld l lkj ls jl
-      dss fl slk ldf jjdl l ks fl fld lkj js s js ld slk dlkk jl ks l
-      dds ld lkj ll jjss ld jjss s dss s kl ldk dds fl s ldf kl sf slj
-      kl sf lkj dss slk dss ls ls fl sf kl ll kl ld jjss dds kl fld
-      jjdl fl js jl sf kl kl jl jl ldf ll dds dds s ll slk dks slj lkj
-      fld kl ks rs fl kl ldk ld l</text>
+<id>{b6c4526a-847b-4e78-b233-c9367469e415}</id>
+<title>l and s</title>
+<newCharacters>ls</newCharacters>
+<text>fl s l ldk l s slj s dks sf kl ll ls l ls dss lkj slk ks
+jl jjss l slj jl lkj l ldf s ld ll l ll ldk jjdl dlkk fl rs dss
+fld fl kl fl fl lkj fld ld fld js l dss kl jl jl ldk fld s ls s
+js kl ll ld dss fld l rs sf dss ll jl kl ls slj kl ldf kl dss rs
+ls js s dlkk js kl js ls fld jl jjdl ll jjdl ll rs ldf rs ld ldk
+slj slj fl fld lkj rs ldf dlkk dss rs fl ld ldk kl dks fl sf dks
+ldk slj kl sf dlkk fl s kl l ll fl slj ll s s s dds s sf fld ks
+ks s ll dss s sf dks fl ldf dks rs ld s jjss ll l slk kl dks sf
+ll ldf s ll dlkk rs jl l ll ls l ldk ldk js dss rs s slj l dks
+fld jl ks dss dlkk ls kl ks kl js kl ldk kl ls l slk dlkk lkj
+slj dks ld dks rs ldf dlkk ls s rs jjdl slk ldk slk dds lkj lkj
+s jjdl fl l s kl slk jjss ls ll dss sf slj dlkk jl fl kl fl jl
+rs ls ll lkj lkj ls lkj kl fl fl ll fl dks l dlkk kl s ldk fl fl
+ks l kl ldf js slk fld dds l ldk ll dlkk jjss l lkj slk jl fl
+ldf ll fl l fl jjss ls ldk ll dks kl slj ldf kl dlkk slk jjdl sf
+dlkk dlkk fld ld s ls dlkk ld kl jl kl fl ls kl ls kl l sf l ls
+ldf dlkk kl sf fl ks lkj fl jjdl ldk ls jjdl dlkk dlkk ldk rs sf
+slj ld s l js ldf fld ldf dks ks ll jjdl slj fld dlkk s js l
+jjdl s s ks ld ll lkj dds ldk ls fl ldk dss jl sf fld kl rs rs
+ll ldf s dks ls ls dds slj dlkk jl l slk sf dks dks rs ldk jl
+dks l dlkk l ks rs ks dks ks fld dds dss ldk kl s ks dks slk fl
+slj dds fl s js jjss kl dks s fl rs s rs ldf ls sf ls ll rs sf
+dds dss jjdl l slk ldk rs kl ld ll kl ll fl jjss ls ldf ll jjss
+kl ll jjdl jjss sf ld jjdl ks ld js l slj jjdl fl sf lkj kl rs
+jjdl ks s dds dss fl slk ll l l slj fl dss js lkj fld ks lkj ks
+ldk jjss ll ld l kl js fl rs ls s s sf dds jl fld l lkj ls jl
+dss fl slk ldf jjdl l ks fl fld lkj js s js ld slk dlkk jl ks l
+dds ld lkj ll jjss ld jjss s dss s kl ldk dds fl s ldf kl sf slj
+kl sf lkj dss slk dss ls ls fl sf kl ll kl ld jjss dds kl fld
+jjdl fl js jl sf kl kl jl jl ldf ll dds dds s ll slk dks slj lkj
+fld kl ks rs fl kl ldk ld l</text>
     </lesson>
     <lesson>
-      <id>{38799882-fc6c-4b51-9d75-1f57ba8834be}</id>
-      <title>c and a</title>
-      <newCharacters>ca</newCharacters>
-      <text>call rascals slacks flaks fads fad flack scads flask
-      jackals flack sass all salsa jackals rad lads flaks scald ca la
-      asks flack lacks ask ad jackal fas las sad sass skas ck ca fad
-      fad adj fas kc dad jacks class lad scald cads jackal ad cads
-      sack alas scald lacs flak alfalfa calls jacks ala dc lacks class
-      lad clack a fads alacks rads ads flask adds scalds c jacks
-      jackals rascal cask ads raj add adds aka scald calla salsas alls
-      sac cads salads fads cask adds casks sacs jackal lacks class
-      clad rack dad slack fall alfalfas slacks fad cal lad cal calla
-      ad sad salads ska salad flack skas ca jacks rascal ads ad flak
-      aka ala ac clad alacks ck jackal fall fas scads call calla
-      alfalfas calf falls flak lack flak flaks casks flak lass flack
-      class la aka flasks rad a skas scad racks ac scad lac skas scald
-      sacs lads rascals call scad call clads kcal salsa slack rascals
-      dads call c alfalfa sack alfalfas falls ask fas calls asks class
-      jack asks alls alack calls alacks rads casks cs kc jackal lacs
-      flak rascals a fall ad ck kcal alfalfa ad a flaks sacks alas ca
-      lad salsas sac skas clads jackass rad alfalfas lacks ska alack
-      flaks as ska cads jackass ala flack falls cads fad scads lac
-      rads ask callas scalds ads skas salsas fall aka salsa flack alls
-      flacks las salads cs salsas racks flack sacks sass lacs cal
-      flacks jacks raj aka alack flacks flack ask dad flacks ads kcal
-      cal jackass cads asks ala callas jacks alfalfa sac flack salsa
-      racks sacs clad ck dc cf ac casks rad scald callas fad dc clacks
-      all falls salads calla skas calls adds jackals casks scalds las
-      clad lacs cask alacks kcal jack flak salads flacks fas sacks
-      salsa jackass ca alfalfa clad calls adj dads lacks fads fall
-      flacks salad clads call callas dc calla kc clad ska lacks asks
-      lack jackal ac fa alas cc lad jackass alack las slack ad ck ca
-      rascals scald add ck flak cads slack ad clad clad fad cask call
-      alacks scads lacks lass falls dads ca lacs rack a clack skas
-      calf rad jack slacks salads adds dads salad flacks cs call cs la
-      fad sac clads flack as</text>
+<id>{38799882-fc6c-4b51-9d75-1f57ba8834be}</id>
+<title>c and a</title>
+<newCharacters>ca</newCharacters>
+<text>call rascals slacks flaks fads fad flack scads flask
+jackals flack sass all salsa jackals rad lads flaks scald ca la
+asks flack lacks ask ad jackal fas las sad sass skas ck ca fad
+fad adj fas kc dad jacks class lad scald cads jackal ad cads
+sack alas scald lacs flak alfalfa calls jacks ala dc lacks class
+lad clack a fads alacks rads ads flask adds scalds c jacks
+jackals rascal cask ads raj add adds aka scald calla salsas alls
+sac cads salads fads cask adds casks sacs jackal lacks class
+clad rack dad slack fall alfalfas slacks fad cal lad cal calla
+ad sad salads ska salad flack skas ca jacks rascal ads ad flak
+aka ala ac clad alacks ck jackal fall fas scads call calla
+alfalfas calf falls flak lack flak flaks casks flak lass flack
+class la aka flasks rad a skas scad racks ac scad lac skas scald
+sacs lads rascals call scad call clads kcal salsa slack rascals
+dads call c alfalfa sack alfalfas falls ask fas calls asks class
+jack asks alls alack calls alacks rads casks cs kc jackal lacs
+flak rascals a fall ad ck kcal alfalfa ad a flaks sacks alas ca
+lad salsas sac skas clads jackass rad alfalfas lacks ska alack
+flaks as ska cads jackass ala flack falls cads fad scads lac
+rads ask callas scalds ads skas salsas fall aka salsa flack alls
+flacks las salads cs salsas racks flack sacks sass lacs cal
+flacks jacks raj aka alack flacks flack ask dad flacks ads kcal
+cal jackass cads asks ala callas jacks alfalfa sac flack salsa
+racks sacs clad ck dc cf ac casks rad scald callas fad dc clacks
+all falls salads calla skas calls adds jackals casks scalds las
+clad lacs cask alacks kcal jack flak salads flacks fas sacks
+salsa jackass ca alfalfa clad calls adj dads lacks fads fall
+flacks salad clads call callas dc calla kc clad ska lacks asks
+lack jackal ac fa alas cc lad jackass alack las slack ad ck ca
+rascals scald add ck flak cads slack ad clad clad fad cask call
+alacks scads lacks lass falls dads ca lacs rack a clack skas
+calf rad jack slacks salads adds dads salad flacks cs call cs la
+fad sac clads flack as</text>
     </lesson>
     <lesson>
-      <id>{5a13d001-b363-4115-8860-2374fb225b52}</id>
-      <title>n and t</title>
-      <newCharacters>nt</newCharacters>
-      <text>catcall tn flanks last scans rands talc knack n cancans
-      talk canst anal canst fan asst stats at natl stall stall alt
-      rands snacks stand assn ants alt tads cantata talcs natl attack
-      knacks stalks tack tact ltd rattan scan scandals fats rats tad
-      talk stalks scats rank rats daft n fatals fat nasal aft cants
-      anal flan knacks natal at acts at scats ts and stank act ct
-      flans canal flan flans stat fats caftan sank cant tads talcs
-      fats act tacts tanks assn slat ransacks flatlands attacks kn
-      assn sandal alts rants kt flats rt rattans knack cat rafts lat
-      assn snack flatlands ans cats stands anal anal ants rattan
-      cancans talc flt tasks cancans ltd scandal canals stalks tat
-      aslant tad flatlands tans flank cast flatland tanks natl snacks
-      n sands talcs natal annal attacks slants anal canst rants act
-      stanks tasks slants flanks flat act rt clank fatal stalk rat
-      sand sandals fast tads tact fatals dank attacks attn caftan
-      flatlands ctn kn tans tack fact flank rants cats sandal stall
-      land knack flanks rat rattan fats talcs catcall fats aslant lat
-      ct slats st scandal tank slants fatal fat stall sank lats
-      cantata acct tasks jct fast nd scandal fats stat rats fatal an
-      skat alts an scats ant fatals fast t ransacks an fan tacks cast
-      clans alts casts flan fatal cans nasals caftan attn fans lats
-      ctn lat stanks ransack can ransacks slats canals ltd natal anal
-      scans stall flatland knacks aft canal rant flats rant daft salts
-      tats snack fats attn tack scandals knack tacts stands asst cats
-      ran natl landfalls fact ands rats t rats nd tan stand caftan
-      tacts can natal act rats scan daft rank slants stat sank stanks
-      tall lands flt stands rat lank rt flatlands sandal staff fats kt
-      fat flank sandal ctn staff rands salt skat scants rat t cant ct
-      an flanks scandals flatlands tads stand tat clanks at ands
-      ransacks alts ts snacks assn tanks flatlands stack lands
-      scandals scats cancan rant jct atlas flanks tact flatland casts
-      scandals n scans task canst std annal clans raft cats tacts flat
-      ants fasts tank an std rt rands cats flt attack act cancans
-      stains fist livid cicada kiss vials knits stilt ails kills flail
-      tail</text>
+<id>{5a13d001-b363-4115-8860-2374fb225b52}</id>
+<title>n and t</title>
+<newCharacters>nt</newCharacters>
+<text>catcall tn flanks last scans rands talc knack n cancans
+talk canst anal canst fan asst stats at natl stall stall alt
+rands snacks stand assn ants alt tads cantata talcs natl attack
+knacks stalks tack tact ltd rattan scan scandals fats rats tad
+talk stalks scats rank rats daft n fatals fat nasal aft cants
+anal flan knacks natal at acts at scats ts and stank act ct
+flans canal flan flans stat fats caftan sank cant tads talcs
+fats act tacts tanks assn slat ransacks flatlands attacks kn
+assn sandal alts rants kt flats rt rattans knack cat rafts lat
+assn snack flatlands ans cats stands anal anal ants rattan
+cancans talc flt tasks cancans ltd scandal canals stalks tat
+aslant tad flatlands tans flank cast flatland tanks natl snacks
+n sands talcs natal annal attacks slants anal canst rants act
+stanks tasks slants flanks flat act rt clank fatal stalk rat
+sand sandals fast tads tact fatals dank attacks attn caftan
+flatlands ctn kn tans tack fact flank rants cats sandal stall
+land knack flanks rat rattan fats talcs catcall fats aslant lat
+ct slats st scandal tank slants fatal fat stall sank lats
+cantata acct tasks jct fast nd scandal fats stat rats fatal an
+skat alts an scats ant fatals fast t ransacks an fan tacks cast
+clans alts casts flan fatal cans nasals caftan attn fans lats
+ctn lat stanks ransack can ransacks slats canals ltd natal anal
+scans stall flatland knacks aft canal rant flats rant daft salts
+tats snack fats attn tack scandals knack tacts stands asst cats
+ran natl landfalls fact ands rats t rats nd tan stand caftan
+tacts can natal act rats scan daft rank slants stat sank stanks
+tall lands flt stands rat lank rt flatlands sandal staff fats kt
+fat flank sandal ctn staff rands salt skat scants rat t cant ct
+an flanks scandals flatlands tads stand tat clanks at ands
+ransacks alts ts snacks assn tanks flatlands stack lands
+scandals scats cancan rant jct atlas flanks tact flatland casts
+scandals n scans task canst std annal clans raft cats tacts flat
+ants fasts tank an std rt rands cats flt attack act cancans
+stains fist livid cicada kiss vials knits stilt ails kills flail
+tail</text>
     </lesson>
     <lesson>
-      <id>{48dc988d-a78b-457d-8601-2636ffa88185}</id>
-      <title>i and v</title>
-      <newCharacters>iv</newCharacters>
-      <text>stains fist livid cicada kiss vials knits stilt ails kills
-      flail tail canvass vats kiln tin fascistic stilt lilacs assails
-      vials ninja lilac inks visit faddists activists cliffs
-      clinicians dint sadist dills sci snit distinct tit kit radians
-      incl saids classical classic i dick tints vasts fascias divans
-      rancid vasts nick sits ills stints saliva titans kickstand
-      fatalist classic tick clink flick slink attic kind avant antacid
-      finalist sills clink distaff did kicks tactics rainfall lifts
-      jail did snit radii raisins stains stilt tidal cavils kill
-      avasts fill finals fatalists distaff fills civilians visits cit
-      finalists statistic fantails skit intact faints vis ails viscid
-      distaffs kilts riff fains link sci rink diff sisals inland ii
-      radiant nails slit island install clinicians kills civil sits
-      stiff riv vans filial canvass invalid flit activist assistant
-      installs raisins tactics skiffs ti kickstand still skinflint
-      alkali antacids dials dills invalids rival clicks cacti
-      racialist sadistic kidskins assail kinda vandal instant kin
-      classicists classicists infants fill assist villain didst knits
-      ti stadias fiats saint rails assassin sciatics ill fiats
-      disdains lain assist avid davit fantails ii landfills vial it
-      ink jinns skids indistinct iv sics riff kicks dillis till
-      radiant satanical antics kills flail dials cavil advt avians vi
-      lints tits lackadaisic addict sics fascist naval lists slit
-      lists tannin sniffs skids fantasist lint vacant clvi fantail
-      fantail clink canvass civilians stain catkins lain sciatics
-      classical raisin nit silks valiants ails satanical akin staid
-      fantail kiss rids satanic fains island kilt kins links ids
-      inkstand kins saids ind ilks initials instincts livid inland
-      visa filial ticks inf finical rain fanatical rill lilacs alias
-      sciatica diffs kickstands fin rill val vitals still attic
-      instant fink riff tannins slick divas sin clinical slid cits
-      jilt atavistic dial scintillas inflict tannin links afflicts
-      distaffs ilks tills flaccid scintillas assailant radiants
-      satanic cilia rink didactics i lilt ilks lackadaisic didst knit
-      tits</text>
+<id>{48dc988d-a78b-457d-8601-2636ffa88185}</id>
+<title>i and v</title>
+<newCharacters>iv</newCharacters>
+<text>stains fist livid cicada kiss vials knits stilt ails kills
+flail tail canvass vats kiln tin fascistic stilt lilacs assails
+vials ninja lilac inks visit faddists activists cliffs
+clinicians dint sadist dills sci snit distinct tit kit radians
+incl saids classical classic i dick tints vasts fascias divans
+rancid vasts nick sits ills stints saliva titans kickstand
+fatalist classic tick clink flick slink attic kind avant antacid
+finalist sills clink distaff did kicks tactics rainfall lifts
+jail did snit radii raisins stains stilt tidal cavils kill
+avasts fill finals fatalists distaff fills civilians visits cit
+finalists statistic fantails skit intact faints vis ails viscid
+distaffs kilts riff fains link sci rink diff sisals inland ii
+radiant nails slit island install clinicians kills civil sits
+stiff riv vans filial canvass invalid flit activist assistant
+installs raisins tactics skiffs ti kickstand still skinflint
+alkali antacids dials dills invalids rival clicks cacti
+racialist sadistic kidskins assail kinda vandal instant kin
+classicists classicists infants fill assist villain didst knits
+ti stadias fiats saint rails assassin sciatics ill fiats
+disdains lain assist avid davit fantails ii landfills vial it
+ink jinns skids indistinct iv sics riff kicks dillis till
+radiant satanical antics kills flail dials cavil advt avians vi
+lints tits lackadaisic addict sics fascist naval lists slit
+lists tannin sniffs skids fantasist lint vacant clvi fantail
+fantail clink canvass civilians stain catkins lain sciatics
+classical raisin nit silks valiants ails satanical akin staid
+fantail kiss rids satanic fains island kilt kins links ids
+inkstand kins saids ind ilks initials instincts livid inland
+visa filial ticks inf finical rain fanatical rill lilacs alias
+sciatica diffs kickstands fin rill val vitals still attic
+instant fink riff tannins slick divas sin clinical slid cits
+jilt atavistic dial scintillas inflict tannin links afflicts
+distaffs ilks tills flaccid scintillas assailant radiants
+satanic cilia rink didactics i lilt ilks lackadaisic didst knit
+tits</text>
     </lesson>
     <lesson>
-      <id>{279e903e-d356-4504-b743-26f2bdd64f0a}</id>
-      <title>m and e</title>
-      <newCharacters>me</newCharacters>
-      <text>vitiated eidetic massive villainies leeks divisiveness
-      academic cadence fest vies catcalled fattest attest fies canes
-      faille addenda vaccinate jaded decline sickie rinded vine leasts
-      revive ices riskiest incisivenesses females staidness stake
-      manic staminas neat decides intimateness acme tinkles metals
-      dailiness selectness satellite lintiest e amends sees deices
-      stets sites definitiveness dens scaliness caste latte slimed
-      effected identical sedative infancies candles eclecticism dialed
-      isled silliness cellmate vilenesses fennels satellited reselects
-      evidence flatted decline intestate lien tanked cleans steed
-      ideals vastest rem citified nines aves disaffiliate efficiencies
-      sleeted militias incidence satiate scientists esteem seeded
-      clacked ms eave incandescence facets mist laked tea
-      incisivenesses destinate deficiencies selective eel cavalcades
-      lifelines maned skinninesses dace talkie dedicative diffidence
-      relatives react divinities dateless fitments seated dims saddled
-      eccl cackle clamminess likeness massiveness invaded aliases
-      adjacent mistiest nicest infields delineate vilenesses nannies
-      reddened effacements ideals stalactite neckline acned talent
-      nattiest deceased lankiest risked annalen diddled semis ramifies
-      eden eventides addictiveness ravened nineteens calcifies devices
-      sassed ramses llama dietetic kitties elitists faked steeliness
-      remiss daffiness amnesic sneakiness limed jests safetied fees
-      kennel datasets sienna milts desists resit smelt enlist
-      desalinated ailed landsmen idealisms finales recast deviant
-      smellinesses dimmest defended stemmed vealed endless laities
-      sidelines stamina reinfected lamest keeled riflemen caffeine
-      semifinals smalls anviled staminate declassified vales
-      divinities ratified elf dialectical incisivenesses ineffective
-      aimed deiced dented flimsiness skedaddles desiccate reselects
-      vindicates maniacs malled raffles advance assisted stillest
-      calmnesses incises salient damn scientist steadfastnesses seen
-      facileness filename emitted deescalates attentivenesses keenness
-      ville indite recidivist venialness sedatives easements enticed
-      feted steeliness leafed facets rel measled dalliance
-      indecisiveness</text>
+<id>{279e903e-d356-4504-b743-26f2bdd64f0a}</id>
+<title>m and e</title>
+<newCharacters>me</newCharacters>
+<text>vitiated eidetic massive villainies leeks divisiveness
+academic cadence fest vies catcalled fattest attest fies canes
+faille addenda vaccinate jaded decline sickie rinded vine leasts
+revive ices riskiest incisivenesses females staidness stake
+manic staminas neat decides intimateness acme tinkles metals
+dailiness selectness satellite lintiest e amends sees deices
+stets sites definitiveness dens scaliness caste latte slimed
+effected identical sedative infancies candles eclecticism dialed
+isled silliness cellmate vilenesses fennels satellited reselects
+evidence flatted decline intestate lien tanked cleans steed
+ideals vastest rem citified nines aves disaffiliate efficiencies
+sleeted militias incidence satiate scientists esteem seeded
+clacked ms eave incandescence facets mist laked tea
+incisivenesses destinate deficiencies selective eel cavalcades
+lifelines maned skinninesses dace talkie dedicative diffidence
+relatives react divinities dateless fitments seated dims saddled
+eccl cackle clamminess likeness massiveness invaded aliases
+adjacent mistiest nicest infields delineate vilenesses nannies
+reddened effacements ideals stalactite neckline acned talent
+nattiest deceased lankiest risked annalen diddled semis ramifies
+eden eventides addictiveness ravened nineteens calcifies devices
+sassed ramses llama dietetic kitties elitists faked steeliness
+remiss daffiness amnesic sneakiness limed jests safetied fees
+kennel datasets sienna milts desists resit smelt enlist
+desalinated ailed landsmen idealisms finales recast deviant
+smellinesses dimmest defended stemmed vealed endless laities
+sidelines stamina reinfected lamest keeled riflemen caffeine
+semifinals smalls anviled staminate declassified vales
+divinities ratified elf dialectical incisivenesses ineffective
+aimed deiced dented flimsiness skedaddles desiccate reselects
+vindicates maniacs malled raffles advance assisted stillest
+calmnesses incises salient damn scientist steadfastnesses seen
+facileness filename emitted deescalates attentivenesses keenness
+ville indite recidivist venialness sedatives easements enticed
+feted steeliness leafed facets rel measled dalliance
+indecisiveness</text>
     </lesson>
     <lesson>
-      <id>{850e6535-8786-4b72-9d62-90e41c1aee8f}</id>
-      <title>h and r</title>
-      <newCharacters>hr</newCharacters>
-      <text>indiscreetness tethers metalsmith takers retire
-      erectnesses skirmish reticent infirmed slithered discards shads
-      thirteenths evaders reliances diversifier headsets shiver
-      transected arrears carnal harrier half arches christen edifier
-      marinated have inheres antimatters finches karat arsines minters
-      richer screamer sandier herd liverish frets draftees strainers
-      heaver darkens hi refinance trials cricketers emir rid
-      disenchantment jerked varietals deerstalkers recheck schematic
-      scarinesses finish thanked hies macerates incarcerate
-      decremental hid credit enrich heelers rakishnesses addresser
-      discarder thickens snarliest cheeriness jihads vhf rectifier
-      hences teaches schemed clenched afresh stashed strive mandrill
-      teethe retiree ranched rends dirtier disasters rareness
-      sacristan iterate fishnets restarts heist caramel sheafs
-      ammeters freshnesses cider rednecked reachieved knish hearths
-      incinerated infielder transcendent reinvestments mansard
-      diameters hardness ethnics retailed fracas airfield mainstream
-      redeclared fader ajar jeer reffed thirsts shavers mercantile
-      clerics scimitars nectar dressier ravishers reseals simmered
-      assister candider namer flashcards traced irenic machineries
-      inkers astrals tired fresher freckled chilled fermenter mere
-      deriver masker transited federalists shelter raisers chasteness
-      masteries snitches servileness differentiate teeshirts
-      careerists desecrates trinkets mavericks rednecks larded
-      intervenes readdress arthritics sanitarians mechanist friskiness
-      simmered inerts advertiser tethered fattener marten interdictive
-      dreader tanneries checks ethical heretical stitch incriminated
-      skinhead steerer craftinesses sheath mechanist starch faster
-      kirsch anthem circle arterial assenter reach limiters mistrals
-      serviceman callers redden dentistries internees distractive
-      interlards rear hadst redivides actress startle fleshliest
-      enriched sinner interlarded refines alchemies innervate severe
-      scarfs fifer hives saltier sered craven machete fickler
-      entrenchment defer referrals tritest marveled transferences
-      arrests verticalness halites redder starless halal derived
-      scalars faltered dithers immerser discreetnesses hastiest
-      arriver</text>
+<id>{850e6535-8786-4b72-9d62-90e41c1aee8f}</id>
+<title>h and r</title>
+<newCharacters>hr</newCharacters>
+<text>indiscreetness tethers metalsmith takers retire
+erectnesses skirmish reticent infirmed slithered discards shads
+thirteenths evaders reliances diversifier headsets shiver
+transected arrears carnal harrier half arches christen edifier
+marinated have inheres antimatters finches karat arsines minters
+richer screamer sandier herd liverish frets draftees strainers
+heaver darkens hi refinance trials cricketers emir rid
+disenchantment jerked varietals deerstalkers recheck schematic
+scarinesses finish thanked hies macerates incarcerate
+decremental hid credit enrich heelers rakishnesses addresser
+discarder thickens snarliest cheeriness jihads vhf rectifier
+hences teaches schemed clenched afresh stashed strive mandrill
+teethe retiree ranched rends dirtier disasters rareness
+sacristan iterate fishnets restarts heist caramel sheafs
+ammeters freshnesses cider rednecked reachieved knish hearths
+incinerated infielder transcendent reinvestments mansard
+diameters hardness ethnics retailed fracas airfield mainstream
+redeclared fader ajar jeer reffed thirsts shavers mercantile
+clerics scimitars nectar dressier ravishers reseals simmered
+assister candider namer flashcards traced irenic machineries
+inkers astrals tired fresher freckled chilled fermenter mere
+deriver masker transited federalists shelter raisers chasteness
+masteries snitches servileness differentiate teeshirts
+careerists desecrates trinkets mavericks rednecks larded
+intervenes readdress arthritics sanitarians mechanist friskiness
+simmered inerts advertiser tethered fattener marten interdictive
+dreader tanneries checks ethical heretical stitch incriminated
+skinhead steerer craftinesses sheath mechanist starch faster
+kirsch anthem circle arterial assenter reach limiters mistrals
+serviceman callers redden dentistries internees distractive
+interlards rear hadst redivides actress startle fleshliest
+enriched sinner interlarded refines alchemies innervate severe
+scarfs fifer hives saltier sered craven machete fickler
+entrenchment defer referrals tritest marveled transferences
+arrests verticalness halites redder starless halal derived
+scalars faltered dithers immerser discreetnesses hastiest
+arriver</text>
     </lesson>
     <lesson>
-      <id>{67d9e774-71b0-4b15-92fd-8e12d90f611e}</id>
-      <title>g and o</title>
-      <newCharacters>go</newCharacters>
-      <text>javelining sledge cockleshell asteroids footfalls raged
-      frothed coaching lanolins conglomerate convalesce groves
-      midnight donors congealing engined revenged secessionist
-      nondrinker noncaloric disconnection scallion derogating
-      griddlecakes knock firefighter reneged relocations songster
-      avitaminosis concierges agitating loosener dermatologist
-      checking smatterings discoloreds slovenliness flatfooted grad
-      overdressing overdoses melioration griddling rigged stomached
-      conservative vacillating loaning overacted gale got official
-      heroisms conservancies vector gel shod denominative ecologist
-      goat deescalation satelliting egret gargled foragers thigh
-      chickening heightens schoolgirl defenestrating mattering carting
-      heretofore offending maisonette goring monasticisms gingham
-      moisten doge alkaloid hadron mastications egotist confiscate
-      ratification hoariest factors jolter loitered gritters arcing
-      canings legginess deformed fleetingnesses rotational senorita
-      oversensitiveness collectivists morion etiological stoke
-      collections alighting kookinesses hookier legated mistaking
-      allocative decollimate fragmented gavel resort toniest shorthand
-      rang fading hemorrhaged coasted doggier contenting notices
-      raccoons groveler gondola gogglers firing erode sidelong
-      cottaging forfends togging striking stockinettes altogether
-      laing kickoff tacking egomanias foretastes oversensitivenesses
-      holiest fragilest introversions medicos nosedives scaffold
-      recoiled latching sentencing rigger condensate calorimetric
-      carillonned degassing evildoings glover commented
-      disconnectednesses cognoscente noncaloric grisliest dosages
-      relocates delineations rocking senior snooks ossifies
-      offhandednesses endorser contritions etiologic recooking
-      signalmen magnolia shedding disregarded collectivists triathlons
-      frosted jingle vialing oldest donnishness grandfathering
-      evensongs smartening redecorate cremations estrangement
-      nonvoters forelocking snorkeling demarcations glorifies idiots
-      dido savored skating valedictions homing gastronomic endangered
-      elevating remove lags shacking revolve correctors cataloging
-      feigner garlands reconciliation marmosets overreacted gladiator
-      selector legatee remelting disintegration comfiest retroactive
-      rove shavings</text>
+<id>{67d9e774-71b0-4b15-92fd-8e12d90f611e}</id>
+<title>g and o</title>
+<newCharacters>go</newCharacters>
+<text>javelining sledge cockleshell asteroids footfalls raged
+frothed coaching lanolins conglomerate convalesce groves
+midnight donors congealing engined revenged secessionist
+nondrinker noncaloric disconnection scallion derogating
+griddlecakes knock firefighter reneged relocations songster
+avitaminosis concierges agitating loosener dermatologist
+checking smatterings discoloreds slovenliness flatfooted grad
+overdressing overdoses melioration griddling rigged stomached
+conservative vacillating loaning overacted gale got official
+heroisms conservancies vector gel shod denominative ecologist
+goat deescalation satelliting egret gargled foragers thigh
+chickening heightens schoolgirl defenestrating mattering carting
+heretofore offending maisonette goring monasticisms gingham
+moisten doge alkaloid hadron mastications egotist confiscate
+ratification hoariest factors jolter loitered gritters arcing
+canings legginess deformed fleetingnesses rotational senorita
+oversensitiveness collectivists morion etiological stoke
+collections alighting kookinesses hookier legated mistaking
+allocative decollimate fragmented gavel resort toniest shorthand
+rang fading hemorrhaged coasted doggier contenting notices
+raccoons groveler gondola gogglers firing erode sidelong
+cottaging forfends togging striking stockinettes altogether
+laing kickoff tacking egomanias foretastes oversensitivenesses
+holiest fragilest introversions medicos nosedives scaffold
+recoiled latching sentencing rigger condensate calorimetric
+carillonned degassing evildoings glover commented
+disconnectednesses cognoscente noncaloric grisliest dosages
+relocates delineations rocking senior snooks ossifies
+offhandednesses endorser contritions etiologic recooking
+signalmen magnolia shedding disregarded collectivists triathlons
+frosted jingle vialing oldest donnishness grandfathering
+evensongs smartening redecorate cremations estrangement
+nonvoters forelocking snorkeling demarcations glorifies idiots
+dido savored skating valedictions homing gastronomic endangered
+elevating remove lags shacking revolve correctors cataloging
+feigner garlands reconciliation marmosets overreacted gladiator
+selector legatee remelting disintegration comfiest retroactive
+rove shavings</text>
     </lesson>
     <lesson>
-      <id>{ca060cf6-46a6-440d-be85-b887d7fee484}</id>
-      <title>b and p</title>
-      <newCharacters>bp</newCharacters>
-      <text>peptides reprimand omnipresences hibernates caper flaps
-      particolored collapse overspreads intercept bespangle anthropoid
-      labors petite adopters pastiche penchant prospected painkiller
-      tampons obsoleting septicemias remembers abolishes entrapment
-      lambed pantie shebangs pervasion transporting toecaps
-      boilermakers shippings bloated precipitation behaviorisms
-      intangibles sandblast sobrieties tabbing pejorative ophthalmic
-      bipartisanship respirators pigpen patriotic peats patresfamilias
-      pointillisms spooled disbanding pitchforked plaited bespattering
-      childbirth apprenticeships privacies clobber preoperative peril
-      dispersals chaplains plodded demographers perming embitterment
-      scrimped rabidnesses fillable pinsetters halfpennies copperheads
-      beechen premier betrothed carbine skateboarding doorstops
-      proceeder platings readership vb sandbags kaleidescope bicarbs
-      perceiving parlance siphoning indispose absenter stockpot
-      halfpence fopperies greasepaint scapegoated span broaches
-      peonage taped provision bivalve blackjacking libidinal
-      bareheaded spottiest napper boobies embroiling boorishness
-      reimpose perspires perfectas scrimping pelf sleepiness flips
-      bedders chamberpot nepenthes basters porringer deprives lappets
-      enveloper shipments considerables hobbles fibroid platoon
-      abortionists piccolos relabels bighted impracticableness
-      attempting blotting gapped brainstorming specialists steepens
-      pearling shockproof taper gabbiness sidebar peens precancels
-      pollinates paramedicals emptinesses philodendrons reparable
-      handpicked halfback fissionables nonparallel corporatism
-      tapeline banister pothole brightens triplicating palleted
-      promotiveness paired composed microscopies reprobation shipper
-      dibbles badmintons tabooed vocabs escapable prince plainsman
-      compilable breadth pariah binded shopkeep poach torpedoing
-      dispossess compartmented contraptions choreographies becalming
-      padre limpidities pref battered peeked blinders presidents
-      bigheartedness backstairs boot obverses flapjack parallelism
-      incorporable repairing impetigos telephoners bemoaning patentee
-      tabor escarpments teachableness prosing pediatrician boninesses
-      impregnated prised nonpersons overemphasis kiboshed abhors
-      helpmate ftps prerecords doorknobs variables tapeline</text>
+<id>{ca060cf6-46a6-440d-be85-b887d7fee484}</id>
+<title>b and p</title>
+<newCharacters>bp</newCharacters>
+<text>peptides reprimand omnipresences hibernates caper flaps
+particolored collapse overspreads intercept bespangle anthropoid
+labors petite adopters pastiche penchant prospected painkiller
+tampons obsoleting septicemias remembers abolishes entrapment
+lambed pantie shebangs pervasion transporting toecaps
+boilermakers shippings bloated precipitation behaviorisms
+intangibles sandblast sobrieties tabbing pejorative ophthalmic
+bipartisanship respirators pigpen patriotic peats patresfamilias
+pointillisms spooled disbanding pitchforked plaited bespattering
+childbirth apprenticeships privacies clobber preoperative peril
+dispersals chaplains plodded demographers perming embitterment
+scrimped rabidnesses fillable pinsetters halfpennies copperheads
+beechen premier betrothed carbine skateboarding doorstops
+proceeder platings readership vb sandbags kaleidescope bicarbs
+perceiving parlance siphoning indispose absenter stockpot
+halfpence fopperies greasepaint scapegoated span broaches
+peonage taped provision bivalve blackjacking libidinal
+bareheaded spottiest napper boobies embroiling boorishness
+reimpose perspires perfectas scrimping pelf sleepiness flips
+bedders chamberpot nepenthes basters porringer deprives lappets
+enveloper shipments considerables hobbles fibroid platoon
+abortionists piccolos relabels bighted impracticableness
+attempting blotting gapped brainstorming specialists steepens
+pearling shockproof taper gabbiness sidebar peens precancels
+pollinates paramedicals emptinesses philodendrons reparable
+handpicked halfback fissionables nonparallel corporatism
+tapeline banister pothole brightens triplicating palleted
+promotiveness paired composed microscopies reprobation shipper
+dibbles badmintons tabooed vocabs escapable prince plainsman
+compilable breadth pariah binded shopkeep poach torpedoing
+dispossess compartmented contraptions choreographies becalming
+padre limpidities pref battered peeked blinders presidents
+bigheartedness backstairs boot obverses flapjack parallelism
+incorporable repairing impetigos telephoners bemoaning patentee
+tabor escarpments teachableness prosing pediatrician boninesses
+impregnated prised nonpersons overemphasis kiboshed abhors
+helpmate ftps prerecords doorknobs variables tapeline</text>
     </lesson>
     <lesson>
-      <id>{331ed5b3-9af3-47fd-9699-7cf2d8ac6f3f}</id>
-      <title>q and u</title>
-      <newCharacters>qu</newCharacters>
-      <text>consult toughs iambuses impugned sequenced
-      thoughtlessnesses staunched heuristics junco flatulent
-      republication humid runnels puffiness underpins practicums
-      escutcheons gunshots summer pounce afoul undifferentiated
-      haircutting brought regurgitate uncalibrated contributions
-      unresponsive louring runoff sunned unmonitored populous
-      actuating scudded unlearn uncap popgun suckles roguish illumined
-      rectangular concurred accountings churl statuettes fugitive
-      annunciators furnaced furred multilevel unestablished documents
-      craniums coupon robustest influence undervalue laughableness
-      fortunateness viaducts turbocharging mournfuller teaspoonful
-      subsequences devalued aforethought infecund arousal quids
-      thoughtless turban submittal unhitch untiring somersault durum
-      individuates unprivileged thousandth caribou soundproofs
-      transfigurations subtractions nucleations universalism quoit
-      curving bequeaths obfuscated unbending umbilical lutenists
-      prematureness restructuring curmudgeons remounting recurring
-      incongruous trustfulness subpopulations gradualist macromolecule
-      minute cruelties multifunctioned butternut constructional
-      overtured scurvier hugger outrunning amputate nucleates
-      courtlinesses mulishnesses haiku sunburned unsupportable
-      compendium bullfrogs elucidations crunches numbness trustiness
-      surgical buddies computerese grubbing annunciation nomenclature
-      routers mucked counseling curricular quadrilaterals measurable
-      shuffleboards sullener unshaped grousers alum duress flumed
-      restaurateurs outboasted fusible credulousnesses stuccoes
-      undefenses scrum formulaic unperformed quadriplegics
-      culpabilities circumference unconfused milieu mutated tunes
-      numismatics pullouts outfit maneuver trumps irruptions budgie
-      diminutiveness cultism hunchback truster publishers sculpture
-      amusers logout muriatic unchanging muck deluging unpartitioned
-      public munched sputters masturbates modularities casualness
-      vacuousness bucketful decorousnesses insulation squealing mutant
-      fatiguing subintervals putrid surmise accouter bivouac
-      unregister adventurousness concourse viaduct opportune obdurated
-      launderers liquidations underpass dubs uncomplaining volumes
-      cubic corpuscles inquietudes avouches glums sunbathe mendacious
-      voguish</text>
+<id>{331ed5b3-9af3-47fd-9699-7cf2d8ac6f3f}</id>
+<title>q and u</title>
+<newCharacters>qu</newCharacters>
+<text>consult toughs iambuses impugned sequenced
+thoughtlessnesses staunched heuristics junco flatulent
+republication humid runnels puffiness underpins practicums
+escutcheons gunshots summer pounce afoul undifferentiated
+haircutting brought regurgitate uncalibrated contributions
+unresponsive louring runoff sunned unmonitored populous
+actuating scudded unlearn uncap popgun suckles roguish illumined
+rectangular concurred accountings churl statuettes fugitive
+annunciators furnaced furred multilevel unestablished documents
+craniums coupon robustest influence undervalue laughableness
+fortunateness viaducts turbocharging mournfuller teaspoonful
+subsequences devalued aforethought infecund arousal quids
+thoughtless turban submittal unhitch untiring somersault durum
+individuates unprivileged thousandth caribou soundproofs
+transfigurations subtractions nucleations universalism quoit
+curving bequeaths obfuscated unbending umbilical lutenists
+prematureness restructuring curmudgeons remounting recurring
+incongruous trustfulness subpopulations gradualist macromolecule
+minute cruelties multifunctioned butternut constructional
+overtured scurvier hugger outrunning amputate nucleates
+courtlinesses mulishnesses haiku sunburned unsupportable
+compendium bullfrogs elucidations crunches numbness trustiness
+surgical buddies computerese grubbing annunciation nomenclature
+routers mucked counseling curricular quadrilaterals measurable
+shuffleboards sullener unshaped grousers alum duress flumed
+restaurateurs outboasted fusible credulousnesses stuccoes
+undefenses scrum formulaic unperformed quadriplegics
+culpabilities circumference unconfused milieu mutated tunes
+numismatics pullouts outfit maneuver trumps irruptions budgie
+diminutiveness cultism hunchback truster publishers sculpture
+amusers logout muriatic unchanging muck deluging unpartitioned
+public munched sputters masturbates modularities casualness
+vacuousness bucketful decorousnesses insulation squealing mutant
+fatiguing subintervals putrid surmise accouter bivouac
+unregister adventurousness concourse viaduct opportune obdurated
+launderers liquidations underpass dubs uncomplaining volumes
+cubic corpuscles inquietudes avouches glums sunbathe mendacious
+voguish</text>
     </lesson>
     <lesson>
-      <id>{db69d42f-a9b0-4c0f-89b2-c3e77fbb3efa}</id>
-      <title>w and n</title>
-      <newCharacters>wn</newCharacters>
-      <text>gantlets buttressing maundered commoners invisible seminal
-      undies antimalarial skewed sandbagged irresistibleness uncling
-      withins anagramming wastered previsioned policemen frangible
-      irreplaceableness trilingual dispassionate garbling impoundments
-      anthropomorphisms misconstrue sunninesses binning flatware
-      vitiations alphanumerical generational maraschinos ignoramuses
-      lingoes blackcurrant pommeling hidden uncoded megalomaniacs
-      derogations deadpans unfold piling piddling barfing reinterview
-      abstractionists hardwoods arbitraging limousines pursuant nerds
-      estranging jawing mavens econometricians muggings isolationisms
-      confinement guesting scullions sandbank beechwood hamstring
-      canons mockingbirds predation numeral universalness
-      decelerations enterer reconquering wideness congregating
-      weakened gravitation snark blindnesses income spongers pancake
-      wabbit casseroling print tensenesses clonk impolitenesses
-      lolling assented injure antisepses distillations kitting
-      predation vivisectionist detuning gunships curbstone sanded woks
-      unvaried immatureness outbuilding bottleneck offhanded
-      casualness linkings underwear toughness wrench chaperoning
-      alliterations squawking wanderlust bobbing invent preordain
-      demand paternal standstill councilpersons nonvoter manumitting
-      shillings masterliness nicenesses aggregations sandpiper
-      signposted ruction whoops illumining counterbalances
-      engorgements flatwares bushiness woodlands sugarcanes resembling
-      subsequentness grimnesses unconventionalities equidistant
-      ringlike swifter shrewdnesses disjointing recipient renaturing
-      intact relinked disfavoring swiss novene unspeaking warehousing
-      concise megaphoned cognates rejuvenated swots unconventional
-      adversenesses ascendant resubmission ravenings desorption
-      foreman tweedier disenchantments mandating nonterminal inflicter
-      momentousnesses bondings wielding enclaved resharpen wonkier
-      encumbrance fraudulent waiverable dinner propagandist
-      irresponsible poaching replacement circumstances detunes
-      germinated methodicalnesses lightninged avowal freeing signified
-      hallow spurning recooking wheaten blissing trimarans planks
-      semantics parenthetical tripping urns niggered offprints
-      unblinking assigned paperhangings disincline disaggregating
-      pushbutton</text>
+<id>{db69d42f-a9b0-4c0f-89b2-c3e77fbb3efa}</id>
+<title>w and n</title>
+<newCharacters>wn</newCharacters>
+<text>gantlets buttressing maundered commoners invisible seminal
+undies antimalarial skewed sandbagged irresistibleness uncling
+withins anagramming wastered previsioned policemen frangible
+irreplaceableness trilingual dispassionate garbling impoundments
+anthropomorphisms misconstrue sunninesses binning flatware
+vitiations alphanumerical generational maraschinos ignoramuses
+lingoes blackcurrant pommeling hidden uncoded megalomaniacs
+derogations deadpans unfold piling piddling barfing reinterview
+abstractionists hardwoods arbitraging limousines pursuant nerds
+estranging jawing mavens econometricians muggings isolationisms
+confinement guesting scullions sandbank beechwood hamstring
+canons mockingbirds predation numeral universalness
+decelerations enterer reconquering wideness congregating
+weakened gravitation snark blindnesses income spongers pancake
+wabbit casseroling print tensenesses clonk impolitenesses
+lolling assented injure antisepses distillations kitting
+predation vivisectionist detuning gunships curbstone sanded woks
+unvaried immatureness outbuilding bottleneck offhanded
+casualness linkings underwear toughness wrench chaperoning
+alliterations squawking wanderlust bobbing invent preordain
+demand paternal standstill councilpersons nonvoter manumitting
+shillings masterliness nicenesses aggregations sandpiper
+signposted ruction whoops illumining counterbalances
+engorgements flatwares bushiness woodlands sugarcanes resembling
+subsequentness grimnesses unconventionalities equidistant
+ringlike swifter shrewdnesses disjointing recipient renaturing
+intact relinked disfavoring swiss novene unspeaking warehousing
+concise megaphoned cognates rejuvenated swots unconventional
+adversenesses ascendant resubmission ravenings desorption
+foreman tweedier disenchantments mandating nonterminal inflicter
+momentousnesses bondings wielding enclaved resharpen wonkier
+encumbrance fraudulent waiverable dinner propagandist
+irresponsible poaching replacement circumstances detunes
+germinated methodicalnesses lightninged avowal freeing signified
+hallow spurning recooking wheaten blissing trimarans planks
+semantics parenthetical tripping urns niggered offprints
+unblinking assigned paperhangings disincline disaggregating
+pushbutton</text>
     </lesson>
     <lesson>
-      <id>{cdd26c2e-c32a-47e7-acec-88279f4670b9}</id>
-      <title>c and x</title>
-      <newCharacters>cx</newCharacters>
-      <text>shadowboxes antacids retrenching cants panache fractious
-      compressor scrawniest elocution scourer thunderclouds unpacking
-      indirections contentiousnesses scaremongers officiation
-      clothespin reselects emetic functioned concoct cinctures wackier
-      corrupting chugging inferencing competitors caribou peacemakings
-      mice luncheon compose commutes tricolored faculties shucker
-      tamaracks contraception stockholder coarsening executions kcal
-      cornucopias commercialisms escaper livestock scubas cares
-      concordant defunct perceives crosspatches nucleation sculptural
-      chugging uncivil betcha exclusion biscuit crouping sanctums
-      commonsense putrescences criming crisis restrictive unsociable
-      biconnected straitjacketing ergonomics braced balaclava
-      disinfecting recited necessitation pellucid uncrossing outscored
-      occulter pecking conformation catgut quitclaiming exacerbate
-      cincturing elasticities nuthatch undercharges obstetrical
-      exalting nonexplosive choirmaster decremented witchcraft
-      perception complicators efficient outbacks licked prancing
-      stacking isotonic exterminators experiment halfback connivance
-      teacups electoral cons ecru poulticing saccharides codgers
-      hesitancies backslashed commencement universalistic smacking
-      maximum electroshocking discords charioted craw carcass cliffs
-      noticed cosmeticians scriptural annunciating vexed scofflaw
-      checkoff gelcap blackcurrant pencil baccalaureates unconcerning
-      reinspected pharmacologist reticulation cravened muckier
-      correcter coffeecup lockets mariachi oculists subscripts
-      constituents commemorator creations scalloping commentates
-      innocentest discipleship captious noninclusive etcher
-      cleanlinesses priceless pathologic cannabises adduct triceratops
-      impracticalness packsaddle lilacs chipmunk muscles trichinoses
-      instructed consenting monstrances evacuative chis cored creped
-      complimented solace parachute cowardice cascara reconvened
-      combats orthorhombic quarterbacking ceriums contour ebullience
-      woodchuck stereoscope expressiveness nitpicking projects
-      beckoning luxuriate conciliating noncaloric ocarina minuscules
-      clambers merchandises lucre crippled technologist authenticator
-      pectic jurisdictions incinerate blackguarded interprocessor
-      teleconferencing watchwords urticarias beseecher clamminess
-      acres curlinesses uncounted</text>
+<id>{cdd26c2e-c32a-47e7-acec-88279f4670b9}</id>
+<title>c and x</title>
+<newCharacters>cx</newCharacters>
+<text>shadowboxes antacids retrenching cants panache fractious
+compressor scrawniest elocution scourer thunderclouds unpacking
+indirections contentiousnesses scaremongers officiation
+clothespin reselects emetic functioned concoct cinctures wackier
+corrupting chugging inferencing competitors caribou peacemakings
+mice luncheon compose commutes tricolored faculties shucker
+tamaracks contraception stockholder coarsening executions kcal
+cornucopias commercialisms escaper livestock scubas cares
+concordant defunct perceives crosspatches nucleation sculptural
+chugging uncivil betcha exclusion biscuit crouping sanctums
+commonsense putrescences criming crisis restrictive unsociable
+biconnected straitjacketing ergonomics braced balaclava
+disinfecting recited necessitation pellucid uncrossing outscored
+occulter pecking conformation catgut quitclaiming exacerbate
+cincturing elasticities nuthatch undercharges obstetrical
+exalting nonexplosive choirmaster decremented witchcraft
+perception complicators efficient outbacks licked prancing
+stacking isotonic exterminators experiment halfback connivance
+teacups electoral cons ecru poulticing saccharides codgers
+hesitancies backslashed commencement universalistic smacking
+maximum electroshocking discords charioted craw carcass cliffs
+noticed cosmeticians scriptural annunciating vexed scofflaw
+checkoff gelcap blackcurrant pencil baccalaureates unconcerning
+reinspected pharmacologist reticulation cravened muckier
+correcter coffeecup lockets mariachi oculists subscripts
+constituents commemorator creations scalloping commentates
+innocentest discipleship captious noninclusive etcher
+cleanlinesses priceless pathologic cannabises adduct triceratops
+impracticalness packsaddle lilacs chipmunk muscles trichinoses
+instructed consenting monstrances evacuative chis cored creped
+complimented solace parachute cowardice cascara reconvened
+combats orthorhombic quarterbacking ceriums contour ebullience
+woodchuck stereoscope expressiveness nitpicking projects
+beckoning luxuriate conciliating noncaloric ocarina minuscules
+clambers merchandises lucre crippled technologist authenticator
+pectic jurisdictions incinerate blackguarded interprocessor
+teleconferencing watchwords urticarias beseecher clamminess
+acres curlinesses uncounted</text>
     </lesson>
     <lesson>
-      <id>{8c97dfe1-0f73-43d5-ae01-70e699492d05}</id>
-      <title>y and z</title>
-      <newCharacters>yz</newCharacters>
-      <text>sylphic detoxifying hypertrophies accompany orthodoxy
-      westernizes incomprehensibility demilitarize universally
-      grippingly esthetically contemporary sedimentary fragility
-      mythically electrolyzed jimmy speedy nudity horseplayer seltzer
-      disqualify imposingly desolately crucially rhythmic capaciously
-      rumply challengingly ingenuously summary lippy unoptimizes
-      individualized factuality flirtatiously abidingly prickly sexily
-      johnnycake consistently legitimization dyslexias uproariously
-      bibliographically toasty dehumanizes microanalytic nonfreezing
-      difficulty abbey understandably instinctively demonetizing buoy
-      laundryman unvarying bilaterally baptizers fogy debauchery
-      vitalizing delightfully lazed yearning scrutinizes kittenishly
-      anaglyph demilitarization depolarize asymmetry terminally
-      scarcely pasteurize mutably seismography epidemically physician
-      collectivized surreptitiously strayer harrying stiltedly
-      patriarchy sanctimoniously searingly tantalized admirably
-      traumatizing gallimaufry unequalized dizzy unsuspectingly
-      ascendancy coweringly reorganizes lyricists internationalizing
-      declamatory pussyfooting richly expressionlessly axiomatization
-      soybean joyfulnesses yellowing warranty slashingly yowled
-      importunely eyefuls inhumanity platitudinously mys miscarrying
-      ridiculously occupy minimizers rowdyism horizon employees
-      pleasingly capillary catalytically propinquity tommy seizable
-      flippantly credibility memorially puppyish eyewash haze paycheck
-      array hydrodynamical hypothyroid effigy campanology polyclinic
-      unorganized acoustically ineffability overcapitalized
-      unparameterized presbyter brotherly inconsistently deputizes
-      archaizes readying telemetry zeppelin incommodiously very damply
-      youthfully descry venously safetying burly locationally rectory
-      modifying exaggeratedly yakked pluralize capsizes situationally
-      rationalizing idiocy subway prodigy leukocyte costively apply
-      cosmetically inappropriately loyalties jazzy thirsty
-      impenitently curly illegally yearned infrequently sukiyaki
-      palatalize ferry tranquilizing globularity sermonizes
-      intellectualizes interdependency depreciatively resolvability
-      trailblazing antithetically syntactics optimizers nanotechnology
-      horseplay housefly soliloquize lamasery thuggery
-      intermolecularly layperson immunizing disarmingly distantly
-      uncriticizing suburbanizing</text>
+<id>{8c97dfe1-0f73-43d5-ae01-70e699492d05}</id>
+<title>y and z</title>
+<newCharacters>yz</newCharacters>
+<text>sylphic detoxifying hypertrophies accompany orthodoxy
+westernizes incomprehensibility demilitarize universally
+grippingly esthetically contemporary sedimentary fragility
+mythically electrolyzed jimmy speedy nudity horseplayer seltzer
+disqualify imposingly desolately crucially rhythmic capaciously
+rumply challengingly ingenuously summary lippy unoptimizes
+individualized factuality flirtatiously abidingly prickly sexily
+johnnycake consistently legitimization dyslexias uproariously
+bibliographically toasty dehumanizes microanalytic nonfreezing
+difficulty abbey understandably instinctively demonetizing buoy
+laundryman unvarying bilaterally baptizers fogy debauchery
+vitalizing delightfully lazed yearning scrutinizes kittenishly
+anaglyph demilitarization depolarize asymmetry terminally
+scarcely pasteurize mutably seismography epidemically physician
+collectivized surreptitiously strayer harrying stiltedly
+patriarchy sanctimoniously searingly tantalized admirably
+traumatizing gallimaufry unequalized dizzy unsuspectingly
+ascendancy coweringly reorganizes lyricists internationalizing
+declamatory pussyfooting richly expressionlessly axiomatization
+soybean joyfulnesses yellowing warranty slashingly yowled
+importunely eyefuls inhumanity platitudinously mys miscarrying
+ridiculously occupy minimizers rowdyism horizon employees
+pleasingly capillary catalytically propinquity tommy seizable
+flippantly credibility memorially puppyish eyewash haze paycheck
+array hydrodynamical hypothyroid effigy campanology polyclinic
+unorganized acoustically ineffability overcapitalized
+unparameterized presbyter brotherly inconsistently deputizes
+archaizes readying telemetry zeppelin incommodiously very damply
+youthfully descry venously safetying burly locationally rectory
+modifying exaggeratedly yakked pluralize capsizes situationally
+rationalizing idiocy subway prodigy leukocyte costively apply
+cosmetically inappropriately loyalties jazzy thirsty
+impenitently curly illegally yearned infrequently sukiyaki
+palatalize ferry tranquilizing globularity sermonizes
+intellectualizes interdependency depreciatively resolvability
+trailblazing antithetically syntactics optimizers nanotechnology
+horseplay housefly soliloquize lamasery thuggery
+intermolecularly layperson immunizing disarmingly distantly
+uncriticizing suburbanizing</text>
     </lesson>
     <lesson>
-      <id>{ef6091fe-54a5-4ead-87d5-4edfd18945e2}</id>
-      <title>Capitalisation</title>
-      <newCharacters>ABCDEFGHIJKLMNOPQRSTUVWXYZ</newCharacters>
-      <text>Tanitansy Issac Dy Lindbergh Kennett Holmes Nicolea Sherm
-      Eloise Gratia Mobutu Leonidas Lexi CCU Goth Reinald Tye Goteborg
-      Gaines Randell Ogdan Mordred Passions Nalani Thomasine Aldous
-      Jacqueline Foley Montpelier Samantha Nadeen Deann Crystie
-      Masonic Vanderbilt Ninetta Gates RFC Darren Wolfgang Norah Tao
-      Lionello Saleem Keefer Boote Micmacs Farmer Cleve Drona Lhasa
-      Bruce Macintosh Grammies Aguirre Dutchman Pissaro Highfield
-      Graehme Dukie Gaylene Thornton Kamikazes Yaounde Clifford Dvina
-      Ellynn Exchequer Korans Angelle MacArthur Sharleen AFB Br Vulcan
-      Karylin Margarette Alfi Caltech Emyle Angola Dexedrine Bendicty
-      Berkowitz Schmitt Oise Subaru Nathalie Ujungpandang Fanechka
-      Kahn Navarro Odie Jacky Highlands Jun Natalie Newcastle Gujarati
-      Shelby LBJ Ramayana Negroid Univac Vistula Kinsey Pole Arvy Hui
-      Byronic QM Jason Baden Talmudic TWX Annetta Babylonian Lehigh
-      Lucille Wesleyan Vanderpoel Stoicisms Rebekkah Louisette Sir
-      Karlee Ricardo Fionna Letti Travis Abagail Tyndale Aug Davide
-      Gabbie GATT NC Bunsen Munchhausen Irkutsk Windows Rom Hyades
-      Melcher Surabaya WV Silurian Verla Harpy Stavros Chaddie Vandyke
-      Bodhisattva Rushmore Bennett Aldo Alane Emilio Gino Galbraith
-      Darwinian Lovecraft Rudy Cornelle Lothaire Afrocentrism Murdock
-      Coletta Grantley Twila Plath Cash Frigga Frenches Deonne Lycras
-      Mahavira Tocantins Melly Wales Cellini Bradney Hartman Stan
-      Mitzi Juliana Occident Dreddy Valera Robson Montenegro Della
-      Delcine Redstone Spengler Ferrel Occidentals Magnuson Jacobs
-      Friend Daffi Methuselahs SBA Asoka Palestine Hatti VT COBOLs
-      Jastrow Malayans ABCs Krakow Hippocratic Tobey Frisian
-      Whitewater Vichy DC Aquila SST Simpson Miguelita Hilliard Zia
-      Dalton Laban Fonzie Charity Lysistrata Kizzee Eocene Ulster
-      Nollie Merrily USA Uranus Sevastopol Padraic Brzezinski Milty
-      Grenada Scrooge Browning Matty Wait Smokey Putin Slesinger
-      Ecstasy Julienne Idahoans Hz Wisconsinites Nations Shiraz Mela
-      McGovern Khan Dusenbury Holman Brena Johannes Gujarati Eberto
-      PAC Annabela Sabbaths Schneider Murcia Moran Houyhnhnm Cronus
-      Ucayali Carnap Leigh Laurence Frito Bert NoDoz Giffy Cecily
-      Noemi Edna</text>
+<id>{ef6091fe-54a5-4ead-87d5-4edfd18945e2}</id>
+<title>Capitalisation</title>
+<newCharacters>ABCDEFGHIJKLMNOPQRSTUVWXYZ</newCharacters>
+<text>Tanitansy Issac Dy Lindbergh Kennett Holmes Nicolea Sherm
+Eloise Gratia Mobutu Leonidas Lexi CCU Goth Reinald Tye Goteborg
+Gaines Randell Ogdan Mordred Passions Nalani Thomasine Aldous
+Jacqueline Foley Montpelier Samantha Nadeen Deann Crystie
+Masonic Vanderbilt Ninetta Gates RFC Darren Wolfgang Norah Tao
+Lionello Saleem Keefer Boote Micmacs Farmer Cleve Drona Lhasa
+Bruce Macintosh Grammies Aguirre Dutchman Pissaro Highfield
+Graehme Dukie Gaylene Thornton Kamikazes Yaounde Clifford Dvina
+Ellynn Exchequer Korans Angelle MacArthur Sharleen AFB Br Vulcan
+Karylin Margarette Alfi Caltech Emyle Angola Dexedrine Bendicty
+Berkowitz Schmitt Oise Subaru Nathalie Ujungpandang Fanechka
+Kahn Navarro Odie Jacky Highlands Jun Natalie Newcastle Gujarati
+Shelby LBJ Ramayana Negroid Univac Vistula Kinsey Pole Arvy Hui
+Byronic QM Jason Baden Talmudic TWX Annetta Babylonian Lehigh
+Lucille Wesleyan Vanderpoel Stoicisms Rebekkah Louisette Sir
+Karlee Ricardo Fionna Letti Travis Abagail Tyndale Aug Davide
+Gabbie GATT NC Bunsen Munchhausen Irkutsk Windows Rom Hyades
+Melcher Surabaya WV Silurian Verla Harpy Stavros Chaddie Vandyke
+Bodhisattva Rushmore Bennett Aldo Alane Emilio Gino Galbraith
+Darwinian Lovecraft Rudy Cornelle Lothaire Afrocentrism Murdock
+Coletta Grantley Twila Plath Cash Frigga Frenches Deonne Lycras
+Mahavira Tocantins Melly Wales Cellini Bradney Hartman Stan
+Mitzi Juliana Occident Dreddy Valera Robson Montenegro Della
+Delcine Redstone Spengler Ferrel Occidentals Magnuson Jacobs
+Friend Daffi Methuselahs SBA Asoka Palestine Hatti VT COBOLs
+Jastrow Malayans ABCs Krakow Hippocratic Tobey Frisian
+Whitewater Vichy DC Aquila SST Simpson Miguelita Hilliard Zia
+Dalton Laban Fonzie Charity Lysistrata Kizzee Eocene Ulster
+Nollie Merrily USA Uranus Sevastopol Padraic Brzezinski Milty
+Grenada Scrooge Browning Matty Wait Smokey Putin Slesinger
+Ecstasy Julienne Idahoans Hz Wisconsinites Nations Shiraz Mela
+McGovern Khan Dusenbury Holman Brena Johannes Gujarati Eberto
+PAC Annabela Sabbaths Schneider Murcia Moran Houyhnhnm Cronus
+Ucayali Carnap Leigh Laurence Frito Bert NoDoz Giffy Cecily
+Noemi Edna</text>
     </lesson>
   </lessons>
 </course>


### PR DESCRIPTION
XML looks to have been auto-formatted. Lesson text was indented by 6 spaces after the first line in every lesson. This removes all leading indent from the file. 